### PR TITLE
Add settings for restoring map state and centering map on start

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/Modules.kt
@@ -13,7 +13,9 @@ import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepositoryImpl
 import com.jordankurtz.piawaremobile.settings.usecase.AddServerUseCase
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
+import com.jordankurtz.piawaremobile.settings.usecase.SetCenterMapOnUserOnStartUseCase
 import com.jordankurtz.piawaremobile.settings.usecase.SetRefreshIntervalUseCase
+import com.jordankurtz.piawaremobile.settings.usecase.SetRestoreMapStateOnStartUseCase
 import io.ktor.client.HttpClient
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
@@ -45,6 +47,8 @@ val useCaseModule = module {
     single { LoadSettingsUseCase(get()) }
     single { AddServerUseCase(get()) }
     single { SetRefreshIntervalUseCase(get()) }
+    single { SetCenterMapOnUserOnStartUseCase(get()) }
+    single { SetRestoreMapStateOnStartUseCase(get()) }
 
     single { SaveMapStateUseCase(get()) }
     single { GetSavedMapStateUseCase(get()) }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
@@ -3,4 +3,6 @@ package com.jordankurtz.piawaremobile.settings
 data class Settings (
     val servers: List<Server>,
     val refreshInterval: Int,
+    val centerMapOnUserOnStart: Boolean,
+    val restoreMapStateOnStart: Boolean
 )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -6,14 +6,18 @@ import com.jordankurtz.piawaremobile.extensions.stateIn
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.usecase.AddServerUseCase
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
+import com.jordankurtz.piawaremobile.settings.usecase.SetCenterMapOnUserOnStartUseCase
 import com.jordankurtz.piawaremobile.settings.usecase.SetRefreshIntervalUseCase
+import com.jordankurtz.piawaremobile.settings.usecase.SetRestoreMapStateOnStartUseCase
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
     loadSettingsUseCase: LoadSettingsUseCase,
     private val addServerUseCase: AddServerUseCase,
-    private val setRefreshIntervalUseCase: SetRefreshIntervalUseCase
+    private val setRefreshIntervalUseCase: SetRefreshIntervalUseCase,
+    private val setCenterMapOnUserOnStartUseCase: SetCenterMapOnUserOnStartUseCase,
+    private val setRestoreMapStateOnStartUseCase: SetRestoreMapStateOnStartUseCase
 ) : ViewModel() {
 
     val settings: StateFlow<Async<Settings>>
@@ -28,4 +32,11 @@ class SettingsViewModel(
         setRefreshIntervalUseCase(refreshInterval)
     }
 
+    fun updateCenterMapOnUserOnStart(enabled: Boolean) = viewModelScope.launch {
+        setCenterMapOnUserOnStartUseCase(enabled)
+    }
+
+    fun updateRestoreMapStateOnStart(enabled: Boolean) = viewModelScope.launch {
+        setRestoreMapStateOnStartUseCase(enabled)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.settings.repo
 
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.jordankurtz.piawaremobile.settings.Settings
@@ -12,6 +13,8 @@ interface SettingsRepository {
     companion object {
         val SERVERS = stringPreferencesKey("servers")
         val REFRESH_INTERVAL = intPreferencesKey("refreshInterval")
+        val CENTER_MAP_ON_USER_ON_START = booleanPreferencesKey("centerMapOnUserOnStart")
+        val RESTORE_MAP_STATE_ON_START = booleanPreferencesKey("restoreMapStateOnStart")
         const val DEFAULT_REFRESH_INTERVAL = 5
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
@@ -17,7 +17,9 @@ class SettingsRepositoryImpl(
         return datastore.data.map {preferences ->
             Settings(
                 servers = preferences[SettingsRepository.SERVERS]?.let { Json.decodeFromString(it) } ?: emptyList(),
-                refreshInterval = preferences[SettingsRepository.REFRESH_INTERVAL] ?: DEFAULT_REFRESH_INTERVAL
+                refreshInterval = preferences[SettingsRepository.REFRESH_INTERVAL] ?: DEFAULT_REFRESH_INTERVAL,
+                centerMapOnUserOnStart = preferences[SettingsRepository.CENTER_MAP_ON_USER_ON_START] ?: false,
+                restoreMapStateOnStart = preferences[SettingsRepository.RESTORE_MAP_STATE_ON_START] ?: false
             )
         }
     }
@@ -26,6 +28,8 @@ class SettingsRepositoryImpl(
         datastore.edit {preferences ->
             preferences[SettingsRepository.SERVERS] = settings.servers.let { Json.encodeToString(it) }
             preferences[SettingsRepository.REFRESH_INTERVAL] = settings.refreshInterval
+            preferences[SettingsRepository.CENTER_MAP_ON_USER_ON_START] = settings.centerMapOnUserOnStart
+            preferences[SettingsRepository.RESTORE_MAP_STATE_ON_START] = settings.restoreMapStateOnStart
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
@@ -81,6 +81,25 @@ fun MainScreen(onServersClicked: () -> Unit) {
                     onValueChange = viewModel::updateRefreshInterval
                 )
             }
+
+            item {
+                SettingsSwitch(
+                    title = "Center map on user",
+                    description = "Automatically center the map on your location when the app starts",
+                    checked = settings.getValue()?.centerMapOnUserOnStart ?: false,
+                    onCheckedChange = viewModel::updateCenterMapOnUserOnStart
+                )
+            }
+
+            item {
+                SettingsSwitch(
+                    title = "Restore map position",
+                    description = "Save and restore the last map position and zoom level on start",
+                    checked = settings.getValue()?.restoreMapStateOnStart ?: true,
+                    onCheckedChange = viewModel::updateRestoreMapStateOnStart
+                )
+            }
+
         }
     }
 }
@@ -160,6 +179,46 @@ fun SettingsNumberInput(
                     .background(Color.LightGray, shape = RoundedCornerShape(4.dp))
                     .padding(horizontal = 8.dp, vertical = 4.dp),
                 textStyle = MaterialTheme.typography.body1.copy(color = if (isValid) Color.Black else Color.Red)
+            )
+        }
+        Divider()
+    }
+}
+
+@Composable
+fun SettingsSwitch(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .clickable { onCheckedChange(!checked) }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.body1
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.caption,
+                    color = Color.Gray
+                )
+            }
+            androidx.compose.material.Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                modifier = Modifier.padding(start = 16.dp)
             )
         }
         Divider()

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SetCenterMapOnUserOnStartUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SetCenterMapOnUserOnStartUseCase.kt
@@ -1,0 +1,15 @@
+package com.jordankurtz.piawaremobile.settings.usecase
+
+import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
+import kotlinx.coroutines.flow.first
+
+class SetCenterMapOnUserOnStartUseCase(
+    private val settingsRepository: SettingsRepository
+) {
+    suspend operator fun invoke(enabled: Boolean) {
+        val currentSettings = settingsRepository.getSettings().first()
+        settingsRepository.saveSettings(
+            currentSettings.copy(centerMapOnUserOnStart = enabled)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SetRestoreMapStateOnStartUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SetRestoreMapStateOnStartUseCase.kt
@@ -1,0 +1,15 @@
+package com.jordankurtz.piawaremobile.settings.usecase
+
+import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
+import kotlinx.coroutines.flow.first
+
+class SetRestoreMapStateOnStartUseCase(
+    private val settingsRepository: SettingsRepository
+) {
+    suspend operator fun invoke(enabled: Boolean) {
+        val currentSettings = settingsRepository.getSettings().first()
+        settingsRepository.saveSettings(
+            currentSettings.copy(restoreMapStateOnStart = enabled)
+        )
+    }
+}


### PR DESCRIPTION
Add settings for controlling if you want to save and restore map state on restart and if you want the map to center on the user on restart. This also fixes an issue where the settings are not refreshed after changing them causing the user to need to restart the app