### PR TITLE
Replace direct API calls with repo and usecases

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,13 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".Application"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
-        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">

--- a/composeApp/src/androidMain/res/xml/network_security_config.xml
+++ b/composeApp/src/androidMain/res/xml/network_security_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">piaware</domain>
-    </domain-config>
-</network-security-config>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareApi.kt
@@ -1,13 +1,11 @@
-package com.jordankurtz.piawaremobile.api
+package com.jordankurtz.piawaremobile.aircraft.api
 
 import com.jordankurtz.piawaremobile.model.Aircraft
-import com.jordankurtz.piawaremobile.model.AircraftInfo
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
 class PiAwareApi(private val httpClient: HttpClient) {
@@ -20,6 +18,7 @@ class PiAwareApi(private val httpClient: HttpClient) {
                 httpClient.get("http://$host/data/aircraft.json").body<PiAwareResponse>()
             response.aircraft
         } catch (e: Exception) {
+            println("Error fetching aircraft: ${e.message}")
             emptyList()
         }
     }
@@ -29,6 +28,7 @@ class PiAwareApi(private val httpClient: HttpClient) {
             httpClient.get("http://$host/db/aircraft_types/icao_aircraft_types.json")
                 .body<Map<String, ICAOAircraftType>>()
         } catch (e: Exception) {
+            println("Error fetching aircraft types: ${e.message}")
             emptyMap()
         }
     }
@@ -41,6 +41,7 @@ class PiAwareApi(private val httpClient: HttpClient) {
                     key
                 ).body<JsonObject>().also { aircraftInfoMap[key] = it }
             } catch (e: Exception) {
+                println("Error fetching aircraft info: ${e.message}")
                 null
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepo.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepo.kt
@@ -1,0 +1,10 @@
+package com.jordankurtz.piawaremobile.aircraft.repo
+
+import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftInfo
+
+interface AircraftRepo {
+    suspend fun getAircraft(servers: List<String>): List<Aircraft>
+    suspend fun loadAircraftTypes(servers: List<String>)
+    suspend fun findAircraftInfo(host: String, hex: String): AircraftInfo?
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
@@ -1,0 +1,91 @@
+package com.jordankurtz.piawaremobile.aircraft.repo
+
+import com.jordankurtz.piawaremobile.aircraft.api.PiAwareApi
+import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftInfo
+import com.jordankurtz.piawaremobile.model.ICAOAircraftType
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+
+class AircraftRepoImpl(private val piAwareApi: PiAwareApi) : AircraftRepo {
+
+    private val aircraftInfoCache = mutableMapOf<String, AircraftInfo>()
+
+    private var aircraftTypes: Map<String, ICAOAircraftType>? = null
+
+    override suspend fun getAircraft(servers: List<String>): List<Aircraft> =
+        coroutineScope {
+            servers.map { server ->
+                async {
+                    try {
+                        piAwareApi.getAircraft(server)
+                    } catch (e: Exception) {
+                        // Log the error and return an empty list for the failed server
+                        println("Failed to fetch aircraft from server $server: ${e.message}")
+                        emptyList()
+                    }
+                }
+            }.awaitAll().flatten()
+        }
+
+    override suspend fun loadAircraftTypes(servers: List<String>) {
+        if (aircraftTypes == null) {
+            aircraftTypes = servers.map { piAwareApi.getAircraftTypes(it) }.flatten()
+        }
+    }
+
+    override suspend fun findAircraftInfo(host: String, hex: String): AircraftInfo? {
+        if (aircraftInfoCache.containsKey(hex)) return aircraftInfoCache[hex]
+
+        val info = lookupAircraftInfoRecursive(host, hex.replace("~", ""))
+        info?.let { aircraftInfoCache[hex] = it }
+        return info
+    }
+
+    private suspend fun lookupAircraftInfoRecursive(
+        host: String,
+        hex: String,
+        level: Int = 1
+    ): AircraftInfo? {
+        val bkey = hex.substring(0, level)
+        val dkey = hex.substring(level)
+
+        val data = piAwareApi.getAircraftInfo(host, bkey) ?: return null
+
+        if (data.containsKey(dkey)) {
+            val info = data[dkey]!!
+            val icaoAircraftType = lookAircraftType(info)
+            return AircraftInfo(
+                registration = info.jsonObject["i"]?.toString(),
+                icaoType = info.jsonObject["t"]?.toString(),
+                typeDescription = icaoAircraftType?.desc,
+                wtc = icaoAircraftType?.wtc
+            )
+        }
+
+        if (data.containsKey("children")) {
+            val subkey = bkey + dkey.substring(0, 1)
+            if (data["children"]?.let { Json.decodeFromJsonElement<List<String>>(it) }
+                    ?.contains(subkey) == true) {
+                return lookupAircraftInfoRecursive(host, hex, level + 1)
+            }
+        }
+
+        return null
+    }
+
+    private fun lookAircraftType(info: JsonElement): ICAOAircraftType? {
+        return info.let { it.jsonObject["t"]?.toString() }
+            ?.let { aircraftTypes?.get(it.uppercase()) }
+    }
+    fun <K, V> List<Map<K, V>>.flatten(): Map<K, V> {
+        val result = mutableMapOf<K, V>()
+        forEach { result.putAll(it) }
+        return result
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/GetAircraftWithDetailsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/GetAircraftWithDetailsUseCase.kt
@@ -1,0 +1,37 @@
+package com.jordankurtz.piawaremobile.aircraft.usecase
+
+import com.jordankurtz.piawaremobile.aircraft.repo.AircraftRepo
+import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftInfo
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * A use case that fetches the list of aircraft from multiple servers and
+ * then enriches each aircraft with its detailed information.
+ */
+class GetAircraftWithDetailsUseCase(
+    private val aircraftRepo: AircraftRepo
+) {
+    /**
+     * Executes the use case.
+     *
+     * @param servers A list of server URLs to fetch aircraft from.
+     * @param infoHost The primary server URL used to look up detailed aircraft info.
+     *                 Often, one server is designated for these lookups.
+     * @return A list of pairs, where each pair contains an [Aircraft] and its corresponding [AircraftInfo].
+     */
+    suspend operator fun invoke(servers: List<String>, infoHost: String): List<Pair<Aircraft, AircraftInfo?>> {
+        val allAircraft = aircraftRepo.getAircraft(servers)
+
+        return coroutineScope {
+            allAircraft.map { aircraft ->
+                async {
+                    val aircraftInfo = aircraftRepo.findAircraftInfo(infoHost, aircraft.hex)
+                    Pair(aircraft, aircraftInfo)
+                }
+            }.awaitAll()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/LoadAircraftTypesUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/LoadAircraftTypesUseCase.kt
@@ -1,0 +1,21 @@
+package com.jordankurtz.piawaremobile.aircraft.usecase
+
+import com.jordankurtz.piawaremobile.aircraft.repo.AircraftRepo
+
+/**
+ * A use case dedicated to loading and caching the aircraft type definitions
+ * from the servers. This should be called once before fetching aircraft details
+ * to ensure the type information is available in the repository's cache.
+ */
+class LoadAircraftTypesUseCase(
+    private val aircraftRepo: AircraftRepo
+) {
+    /**
+     * Executes the use case.
+     *
+     * @param servers A list of server URLs from which to load the type definitions.
+     */
+    suspend operator fun invoke(servers: List<String>) {
+        aircraftRepo.loadAircraftTypes(servers)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/Modules.kt
@@ -1,7 +1,11 @@
 package com.jordankurtz.piawaremobile.di
 
 import com.jordankurtz.piawaremobile.KtorClient
-import com.jordankurtz.piawaremobile.api.PiAwareApi
+import com.jordankurtz.piawaremobile.aircraft.api.PiAwareApi
+import com.jordankurtz.piawaremobile.aircraft.repo.AircraftRepo
+import com.jordankurtz.piawaremobile.aircraft.repo.AircraftRepoImpl
+import com.jordankurtz.piawaremobile.aircraft.usecase.GetAircraftWithDetailsUseCase
+import com.jordankurtz.piawaremobile.aircraft.usecase.LoadAircraftTypesUseCase
 import com.jordankurtz.piawaremobile.map.MapViewModel
 import com.jordankurtz.piawaremobile.map.OpenStreetMapProvider
 import com.jordankurtz.piawaremobile.map.repo.MapStateRepository
@@ -32,6 +36,7 @@ val viewModelModule = module {
 val dataModule = module {
     singleOf(::SettingsRepositoryImpl) { bind<SettingsRepository>() }
     singleOf(::MapStateRepositoryImpl) { bind<MapStateRepository>() }
+    singleOf(::AircraftRepoImpl) { bind<AircraftRepo>() }
 }
 
 val networkModule = module {
@@ -52,6 +57,9 @@ val useCaseModule = module {
 
     single { SaveMapStateUseCase(get()) }
     single { GetSavedMapStateUseCase(get()) }
+
+    single { GetAircraftWithDetailsUseCase(get()) }
+    single { LoadAircraftTypesUseCase(get()) }
 }
 
 expect val platformModule: Module

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -11,25 +11,20 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jordankurtz.piawaremobile.UrlHandler
-import com.jordankurtz.piawaremobile.api.PiAwareApi
+import com.jordankurtz.piawaremobile.aircraft.usecase.GetAircraftWithDetailsUseCase
+import com.jordankurtz.piawaremobile.aircraft.usecase.LoadAircraftTypesUseCase
 import com.jordankurtz.piawaremobile.location.Location
 import com.jordankurtz.piawaremobile.location.LocationService
 import com.jordankurtz.piawaremobile.location.LocationState
 import com.jordankurtz.piawaremobile.map.usecase.GetSavedMapStateUseCase
 import com.jordankurtz.piawaremobile.map.usecase.SaveMapStateUseCase
-import com.jordankurtz.piawaremobile.model.Aircraft
-import com.jordankurtz.piawaremobile.model.AircraftInfo
 import com.jordankurtz.piawaremobile.model.Async
-import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,12 +32,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import ovh.plrapps.mapcompose.api.addLayer
 import ovh.plrapps.mapcompose.api.addMarker
@@ -57,6 +52,7 @@ import ovh.plrapps.mapcompose.ui.layout.Forced
 import ovh.plrapps.mapcompose.ui.state.MapState
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.ic_plane
+import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.ln
 import kotlin.math.pow
@@ -76,20 +72,16 @@ private val dateFormatter = LocalDateTime.Format {
 
 @OptIn(FlowPreview::class)
 class MapViewModel(
-    private val piAwareApi: PiAwareApi,
     private val mapProvider: TileStreamProvider,
     private val loadSettingsUseCase: LoadSettingsUseCase,
     private val urlHandler: UrlHandler,
     private val locationService: LocationService,
     private val getSavedMapStateUseCase: GetSavedMapStateUseCase,
-    private val saveMapStateUseCase: SaveMapStateUseCase
+    private val saveMapStateUseCase: SaveMapStateUseCase,
+    private val loadAircraftTypesUseCase: LoadAircraftTypesUseCase,
+    private val getAircraftWithDetailsUseCase: GetAircraftWithDetailsUseCase
 ) : ViewModel() {
 
-    private lateinit var aircraftTypes: Map<String, ICAOAircraftType>
-
-    private val aircraftInfoCache = mutableMapOf<String, AircraftInfo>()
-
-    // Merged from LocationViewModel
     private val _locationState = MutableStateFlow<LocationState>(LocationState.Idle)
     val locationState: StateFlow<LocationState> = _locationState.asStateFlow()
 
@@ -100,7 +92,6 @@ class MapViewModel(
         get() = _numberOfPlanes
     private val _numberOfPlanes = MutableStateFlow(0)
 
-    // store setting dependent jobs so they can be cancelled and restarted when settings change
     private var pollingJob: Job? = null
     private var saveStateJob: Job? = null
 
@@ -109,150 +100,92 @@ class MapViewModel(
     }.apply {
         addLayer(mapProvider)
 
-        onMarkerClick { id, x, y ->
+        onMarkerClick { id, _, _ ->
             if (!id.startsWith("fake")) {
                 openFlightPage(id)
             }
         }
     }
 
-
     init {
         viewModelScope.launch(Dispatchers.IO) {
             loadSettingsUseCase().collect {
-                val result = it
-                when (result) {
-                    is Async.Success -> onSettingsLoaded(result)
-                    else -> {}
+                if (it is Async.Success) {
+                    onSettingsLoaded(it.data)
                 }
             }
         }
     }
 
-    private fun onSettingsLoaded(result: Async.Success<Settings>) {
+    private fun onSettingsLoaded(settings: Settings) {
         pollingJob?.cancel()
         saveStateJob?.cancel()
 
-        with(result.data) {
-            pollingJob = viewModelScope.launch {
-                pollServers(
-                    servers.map { it.address },
-                    refreshInterval
-                )
-            }
+        pollingJob = viewModelScope.launch {
+            pollServers(
+                settings.servers.map { it.address },
+                settings.refreshInterval
+            )
+        }
 
-            if (restoreMapStateOnStart) {
-                saveStateJob = viewModelScope.launch {
-                    val savedState = getSavedMapStateUseCase()
-                    println("Restored map state $savedState")
-                    state.setScroll(savedState.scrollX, savedState.scrollY)
-                    state.scale = savedState.zoom
+        if (settings.restoreMapStateOnStart) {
+            saveStateJob = viewModelScope.launch {
+                val savedState = getSavedMapStateUseCase()
+                println("Restored map state $savedState")
+                state.setScroll(savedState.scrollX, savedState.scrollY)
+                state.scale = savedState.zoom
 
-                    // wait to center the map on the user's location until after we restore state
-                    if (centerMapOnUserOnStart) {
-                        requestLocationPermission()
-                    }
-
-                    snapshotFlow { Pair(state.scroll, state.scale) }
-                        .debounce(500.milliseconds)
-                        .onEach { (scroll, scale) ->
-                            // This check prevents saving the initial state (0.0, 0.0) before the map is ready
-                            if (scroll.x > 0.0 && scroll.y > 0.0) {
-                                saveMapStateUseCase(scroll.x, scroll.y, scale)
-                                println("Saved map state $scroll, $scale")
-                            }
-                        }.launchIn(this)
+                if (settings.centerMapOnUserOnStart) {
+                    requestLocationPermission()
                 }
-            } else if (result.data.centerMapOnUserOnStart) {
-                // if restore state and centering is on then the map will be centered after state is restore
-                requestLocationPermission()
+
+                snapshotFlow { Pair(state.scroll, state.scale) }
+                    .debounce(500.milliseconds)
+                    .onEach { (scroll, scale) ->
+                        if (scroll.x > 0.0 && scroll.y > 0.0) {
+                            saveMapStateUseCase(scroll.x, scroll.y, scale)
+                            println("Saved map state $scroll, $scale")
+                        }
+                    }.launchIn(this)
             }
+        } else if (settings.centerMapOnUserOnStart) {
+            requestLocationPermission()
         }
     }
 
     private suspend fun pollServers(servers: List<String>, refreshInterval: Int) {
-        aircraftTypes = loadAircraftTypes(servers)
-        while (true) {
+        if (servers.isEmpty()) return
+
+        loadAircraftTypesUseCase(servers)
+        val infoHost = servers.first()
+
+        while (coroutineContext.isActive) {
             println("Refreshing")
-            val aircraft = servers.map { processAircraft(it) }.flatten()
+            val aircraft = getAircraftWithDetailsUseCase(servers, infoHost)
 
             _numberOfPlanes.value = aircraft.count()
 
             state.removeAllMarkers()
 
-            aircraft.forEach {
-                val location = doProjection(it.first.lat, it.first.lon)
+            aircraft.forEach { (plane, _) ->
+                val location = doProjection(plane.lat, plane.lon)
 
                 state.addMarker(
-                    it.first.flight ?: "fake=${it.first.hex}", location.first, location.second
+                    plane.flight ?: "fake=${plane.hex}", location.first, location.second
                 ) {
                     Image(
                         painter = painterResource(Res.drawable.ic_plane),
                         contentDescription = null,
-                        modifier = Modifier.size(30.dp).rotate(it.first.track),
-                        colorFilter = ColorFilter.tint(getColorForAltitude(it.first.altitude))
+                        modifier = Modifier
+                            .size(30.dp)
+                            .rotate(plane.track),
+                        colorFilter = ColorFilter.tint(getColorForAltitude(plane.altitude))
                     )
                 }
             }
 
             delay(refreshInterval.seconds.inWholeMilliseconds)
         }
-    }
-
-    private suspend fun loadAircraftTypes(servers: List<String>) =
-        servers.map { piAwareApi.getAircraftTypes(it) }.flatten()
-
-    private suspend fun processAircraft(server: String): List<Pair<Aircraft, AircraftInfo?>> {
-        return coroutineScope {
-            return@coroutineScope piAwareApi.getAircraft(server).map {
-                async {
-                    Pair(it, getAircraftInfo(server, it.hex.uppercase()))
-                }
-            }.awaitAll()
-        }
-    }
-
-    private suspend fun getAircraftInfo(host: String, hex: String): AircraftInfo? {
-        if (aircraftInfoCache.containsKey(hex)) return aircraftInfoCache[hex]!!
-
-        return lookupAircraftInfo(host, hex.replace("~", ""))
-    }
-
-    private suspend fun lookupAircraftInfo(
-        host: String,
-        hex: String,
-        level: Int = 1
-    ): AircraftInfo? {
-        val bkey = hex.substring(0, level)
-        val dkey = hex.substring(level)
-
-        val data = piAwareApi.getAircraftInfo(host, bkey) ?: return null
-
-        if (data.containsKey(dkey)) {
-            val info = data[dkey]!!
-            val icaoAircraftType = lookAircraftType(info)
-            return AircraftInfo(
-                registration = info.jsonObject["i"]?.toString(),
-                icaoType = info.jsonObject["t"]?.toString(),
-                typeDescription = icaoAircraftType?.desc,
-                wtc = icaoAircraftType?.wtc
-            )
-        }
-
-        if (data.containsKey("children")) {
-            val subkey = bkey + dkey.substring(0, 1)
-            if (data["children"]?.let { Json.decodeFromJsonElement<List<String>>(it) }
-                    ?.contains(subkey) == true) {
-                return lookupAircraftInfo(host, hex, level + 1)
-            }
-        }
-
-        return null
-    }
-
-    private fun lookAircraftType(info: JsonElement): ICAOAircraftType? {
-        return info.let { it.jsonObject["t"]?.toString() }
-            ?.let { aircraftTypes[it.uppercase()] }
     }
 
     fun requestLocationPermission() {
@@ -311,53 +244,45 @@ class MapViewModel(
     }
 
     private fun openFlightPage(flight: String) {
-        urlHandler.openUrl(getFlightAwareUrl(flight))
-    }
-
-    private fun getFlightAwareUrl(flight: String): String {
-        return "https://www.flightaware.com/live/flight/$flight/history/${dateFormatter}.format(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))"
+        val dateString = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        urlHandler.openUrl(
+            "https://www.flightaware.com/live/flight/$flight/history/${
+                dateFormatter.format(
+                    dateString
+                )
+            }"
+        )
     }
 
     private fun getColorForAltitude(altitude: String): Color {
         return when (altitude.toIntOrNull() ?: 0) {
-            in 0..250 -> Color(255, 64, 0)   // Dark Orange
-            in 251..500 -> Color(255, 128, 0)   // Orange
-            in 501..750 -> Color(255, 160, 0)   // Light Orange
-            in 751..1000 -> Color(255, 192, 0)  // Yellowish Orange
-            in 1001..1500 -> Color(255, 224, 0) // Light Yellow Orange
-            in 1501..2000 -> Color(255, 255, 0) // Yellow
-            in 2001..3000 -> Color(192, 255, 0) // Yellow Green
-            in 3001..4000 -> Color(128, 255, 0) // Greenish Yellow
-            in 4001..5000 -> Color(64, 255, 0)  // Light Green
-            in 5001..6000 -> Color(0, 255, 64)  // Slightly Darker Green
-            in 6001..7000 -> Color(0, 255, 128) // Light Green
-            in 7001..8000 -> Color(0, 255, 192) // Aqua Green
-            in 8001..9000 -> Color(0, 255, 224) // Light Cyan Green
-            in 9001..10000 -> Color(0, 255, 255) // Cyan
-            in 10001..15000 -> Color(0, 224, 255) // Light Blue Cyan
-            in 15001..20000 -> Color(0, 192, 255) // Blueish Cyan
-            in 20001..25000 -> Color(0, 160, 255) // Lighter Blue
-            in 25001..30000 -> Color(0, 128, 255) // Blue
-            in 30001..35000 -> Color(0, 64, 255)  // Dark Blue
-            in 35001..40000 -> Color(0, 0, 255)  // Deep Blue
-            in 40001..45000 -> Color(64, 0, 255) // Dark Violet Blue
-            in 45001..50000 -> Color(128, 0, 255) // Violet
-            else -> Color(192, 0, 255) // Brighter Violet for 50,000+
+            in 0..250 -> Color(255, 64, 0)
+            in 251..500 -> Color(255, 128, 0)
+            in 501..750 -> Color(255, 160, 0)
+            in 751..1000 -> Color(255, 192, 0)
+            in 1001..1500 -> Color(255, 224, 0)
+            in 1501..2000 -> Color(255, 255, 0)
+            in 2001..3000 -> Color(192, 255, 0)
+            in 3001..4000 -> Color(128, 255, 0)
+            in 4001..5000 -> Color(64, 255, 0)
+            in 5001..6000 -> Color(0, 255, 64)
+            in 6001..7000 -> Color(0, 255, 128)
+            in 7001..8000 -> Color(0, 255, 192)
+            in 8001..9000 -> Color(0, 255, 224)
+            in 9001..10000 -> Color(0, 255, 255)
+            in 10001..15000 -> Color(0, 224, 255)
+            in 15001..20000 -> Color(0, 192, 255)
+            in 20001..25000 -> Color(0, 160, 255)
+            in 25001..30000 -> Color(0, 128, 255)
+            in 30001..35000 -> Color(0, 64, 255)
+            in 35001..40000 -> Color(0, 0, 255)
+            in 40001..45000 -> Color(64, 0, 255)
+            in 45001..50000 -> Color(128, 0, 255)
+            else -> Color(192, 0, 255)
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        stopLocationUpdates()
     }
 }
 
 private fun mapSizeAtLevel(wmtsLevel: Int, tileSize: Int): Int {
     return tileSize * 2.0.pow(wmtsLevel).toInt()
-}
-
-fun <K, V> List<Map<K, V>>.flatten(): Map<K, V> {
-    val result = mutableMapOf<K, V>()
-    forEach { result.putAll(it) }
-    return result
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/Async.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/Async.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.model
 
+@Suppress("UNCHECKED_CAST")
 sealed class Async<out T> {
     object NotStarted : Async<Nothing>()
     object Loading : Async<Nothing>()

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/LoadSettingsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/LoadSettingsUseCase.kt
@@ -5,9 +5,10 @@ import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 class LoadSettingsUseCase(private val settingsRepository: SettingsRepository) {
     operator fun invoke(): Flow<Async<Settings>> {
-        return settingsRepository.getSettings().async()
+        return settingsRepository.getSettings().distinctUntilChanged().async()
     }
 }


### PR DESCRIPTION
The logic for getting aircraft from the PiAware servers was from when this was just a PoC so it was not architected properly. This updates those parts of the code base to follow the repo and use case pattern from the rest of the APP