### PR TITLE
Fix desktop target compilation and runtime errors

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -84,7 +84,7 @@ kotlin {
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
-            implementation(libs.ktor.client.android)
+            implementation(libs.ktor.client.cio)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/Platform.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/Platform.jvm.kt
@@ -1,8 +1,7 @@
 package com.jordankurtz.piawaremobile
 
-class JVMPlatform: Platform {
+class JVMPlatform : Platform {
     override val name: String = "Java ${System.getProperty("java.version")}"
-    override val dataStorePath = ""
 }
 
 actual fun getPlatform(): Platform = JVMPlatform()

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/DataStoreModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/DataStoreModule.desktop.kt
@@ -12,7 +12,7 @@ actual class DataStoreModule {
     @Single
     actual fun provideDataStore(contextWrapper: ContextWrapper): DataStore<Preferences> {
         return PreferenceDataStoreFactory.createWithPath {
-            ("settings").toPath()
+            ("settings.preferences_pb").toPath()
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/LocationService.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/LocationService.desktop.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Factory
 import java.io.BufferedReader
@@ -77,9 +76,3 @@ actual class LocationServiceImpl actual constructor(private val contextWrapper: 
     }
 }
 
-@Serializable
-data class IPLocationResponse(
-    val status: String,
-    val lat: Double,
-    val lon: Double
-)

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/main.kt
@@ -4,17 +4,25 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.jordankurtz.consolelogger.ConsoleLogger
 import com.jordankurtz.logger.Logger
+import com.jordankurtz.piawaremobile.di.modules.AppModule
 import com.jordankurtz.sentrylogger.SentryLogger
-import io.sentry.kotlin.multiplatform.Sentry
+import org.koin.core.context.startKoin
+import org.koin.ksp.generated.module
 
-fun main() = application {
+fun main() {
     Logger.addWriter(ConsoleLogger())
     Logger.addWriter(SentryLogger(BuildConfig.SENTRY_DSN))
 
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "PiAware Mobile",
-    ) {
-        App()
+    startKoin {
+        modules(AppModule().module)
+    }
+
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "PiAware Mobile",
+        ) {
+            App()
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 uuid = { module = "com.benasher44:uuid", version = "0.8.4" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }


### PR DESCRIPTION
## Summary
- Replace `ktor-client-android` with `ktor-client-cio` for the desktop/JVM target (CIO engine was unresolved)
- Remove stale `dataStorePath` override from `JVMPlatform` (property no longer exists on `Platform` interface)
- Remove duplicate `IPLocationResponse` data class from `LocationService.desktop.kt` (keep standalone file)
- Add missing `startKoin` initialization to desktop `main.kt`
- Fix DataStore file path to include required `.preferences_pb` extension

## Test plan
- [x] `./gradlew :composeApp:desktopTest` passes (91 tests, 0 failures)
- [x] `./gradlew :composeApp:desktopRun` launches without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)