### PR TITLE
Handle empty server list safely in polling

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModel.kt
@@ -98,6 +98,10 @@ class AircraftViewModel(
                     is Async.Success -> {
                         with(it.data) {
                             settings = this
+                            if (servers.isEmpty()) {
+                                stopPolling()
+                                return@collect
+                            }
                             launch { loadHistoryUseCase(servers.map { server -> server.address }) }
                             if (showReceiverLocations) {
                                 loadReceiverLocations(servers)
@@ -148,7 +152,7 @@ class AircraftViewModel(
             isFirstResume = false
             return
         }
-        val servers = settings?.servers?.map { it.address } ?: return
+        val servers = settings?.servers?.map { it.address }?.takeIf { it.isNotEmpty() } ?: return
         Logger.v("Refreshing trail history on resume")
         viewModelScope.launch(ioDispatcher) {
             loadHistoryUseCase(servers)

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
@@ -144,6 +144,43 @@ class AircraftViewModelTest {
         }
 
     @Test
+    fun `empty server list does not start polling or load history`() =
+        runTest {
+            val emptySettings = settings.copy(servers = emptyList())
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(emptySettings))
+
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(0, viewModel.numberOfPlanes.value)
+
+            verifySuspend(mode = VerifyMode.exactly(0)) {
+                loadHistoryUseCase(listOf())
+            }
+            verifySuspend(mode = VerifyMode.exactly(0)) {
+                loadAircraftTypesUseCase(listOf())
+            }
+        }
+
+    @Test
+    fun `onResume with empty server list does not reload history`() =
+        runTest {
+            val emptySettings = settings.copy(servers = emptyList())
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(emptySettings))
+
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onResume() // skip first
+            viewModel.onResume() // should not crash or call loadHistory
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(0)) {
+                loadHistoryUseCase(listOf())
+            }
+        }
+
+    @Test
     fun `polling updates aircraft count`() =
         runTest {
             val viewModel = createViewModel()


### PR DESCRIPTION
## Summary
- Add early return in `AircraftViewModel` init when server list is empty, stopping any existing polling job
- Guard `onResume` against empty server lists with `takeIf { it.isNotEmpty() }`
- Add two unit tests verifying empty server list behavior

## Test plan
- [x] `./gradlew :composeApp:testDebugUnitTest` — all tests pass including 2 new ones
- [x] `./gradlew ktlintCheck detekt` — passes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)