### PR TITLE
Use HTTPS for IP geolocation API

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/IPLocationResponse.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/IPLocationResponse.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class IPLocationResponse(
-    val status: String,
-    val lat: Double,
-    val lon: Double,
+    val success: Boolean,
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
     val city: String? = null,
     val country: String? = null,
 )

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/LocationService.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/location/LocationService.desktop.kt
@@ -51,8 +51,7 @@ actual class LocationServiceImpl actual constructor(private val contextWrapper: 
 
         private fun fetchLocationFromIP(): Location? {
             return try {
-                // Using ip-api.com free API for geolocation
-                val url = URL("http://ip-api.com/json/")
+                val url = URL("https://ipwho.is/")
                 val connection = url.openConnection() as HttpURLConnection
                 connection.requestMethod = "GET"
                 connection.connectTimeout = 5000
@@ -64,10 +63,10 @@ actual class LocationServiceImpl actual constructor(private val contextWrapper: 
 
                 val locationData = json.decodeFromString<IPLocationResponse>(response)
 
-                if (locationData.status == "success") {
+                if (locationData.success) {
                     Location(
-                        latitude = locationData.lat,
-                        longitude = locationData.lon,
+                        latitude = locationData.latitude,
+                        longitude = locationData.longitude,
                     )
                 } else {
                     null


### PR DESCRIPTION
## Summary
- Switch desktop IP geolocation from `http://ip-api.com/json/` to `https://ipwho.is/`
- ip-api.com's free tier only supports HTTP; ipwho.is provides free HTTPS
- Update `IPLocationResponse` model to match ipwho.is response format (`success: Boolean`, `latitude`/`longitude`)

## Test plan
- [x] `./gradlew ktlintCheck detekt` — passes
- [x] Desktop geolocation only used for development/desktop target — verified response format matches via `curl https://ipwho.is/`

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)