### PR TITLE
Increase HTTP timeouts and centralize config

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.android.kt
@@ -21,9 +21,9 @@ actual fun getKtorClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            requestTimeoutMillis = 1000
-            connectTimeoutMillis = 1000
-            socketTimeoutMillis = 1000
+            requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS
+            socketTimeoutMillis = HttpTimeoutDefaults.SOCKET_TIMEOUT_MS
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.kt
@@ -4,6 +4,12 @@ import io.ktor.client.HttpClient
 
 expect fun getKtorClient(): HttpClient
 
+object HttpTimeoutDefaults {
+    const val REQUEST_TIMEOUT_MS = 10_000L
+    const val CONNECT_TIMEOUT_MS = 5_000L
+    const val SOCKET_TIMEOUT_MS = 10_000L
+}
+
 class KtorClient {
     val client: HttpClient
         get() = getKtorClient()

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.desktop.kt
@@ -21,9 +21,9 @@ actual fun getKtorClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            requestTimeoutMillis = 1000
-            connectTimeoutMillis = 1000
-            socketTimeoutMillis = 1000
+            requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS
+            socketTimeoutMillis = HttpTimeoutDefaults.SOCKET_TIMEOUT_MS
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.ios.kt
@@ -21,9 +21,9 @@ actual fun getKtorClient(): HttpClient {
             )
         }
         install(HttpTimeout) {
-            requestTimeoutMillis = 1000
-            connectTimeoutMillis = 1000
-            socketTimeoutMillis = 1000
+            requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS
+            socketTimeoutMillis = HttpTimeoutDefaults.SOCKET_TIMEOUT_MS
         }
         engine {
             configureRequest {


### PR DESCRIPTION
## Summary
- Increase HTTP timeouts from 1s to 10s request / 5s connect / 10s socket across all platforms
- Extract shared `HttpTimeoutDefaults` object in `commonMain/KtorClient.kt` so timeout values are defined once
- Affects Android, iOS, and Desktop Ktor client configurations

The 1-second timeout was causing frequent failures, especially for FlightAware API calls over the internet and PiAware devices on slower WiFi connections.

## Test plan
- [x] `./gradlew ktlintCheck detekt` — passes
- [x] `./gradlew :composeApp:testDebugUnitTest` — passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)