### PR TITLE
Replace deprecated TabRow with PrimaryTabRow

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -14,9 +14,9 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -114,7 +114,7 @@ fun FlightDetailsBottomSheet(
 
                         Spacer(modifier = Modifier.height(8.dp))
 
-                        TabRow(selectedTabIndex = tabIndex) {
+                        PrimaryTabRow(selectedTabIndex = tabIndex) {
                             tabs.forEachIndexed { index, title ->
                                 Tab(
                                     text = { Text(title) },


### PR DESCRIPTION
## Summary
- Replace deprecated `TabRow` with `PrimaryTabRow` in `FlightDetailsBottomSheet.kt`

Closes #60

## Test plan
- [x] All tests pass
- [x] ktlint and detekt pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)