### PR TITLE
Enable R8/ProGuard for release builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -120,7 +120,12 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
     compileOptions {

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,40 @@
+# kotlinx.serialization — keep @Serializable classes and generated serializers
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-keep,includedescriptorclasses class com.jordankurtz.piawaremobile.**$$serializer { *; }
+-keepclassmembers class com.jordankurtz.piawaremobile.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.jordankurtz.piawaremobile.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Koin — keep generated DI module code
+-keep class org.koin.ksp.generated.** { *; }
+
+# Ktor — keep engine and plugin classes
+-keep class io.ktor.** { *; }
+-dontwarn io.ktor.**
+
+# Sentry — keep crash reporting classes
+-dontwarn io.sentry.**
+
+# Coroutines
+-dontwarn kotlinx.coroutines.**
+
+# MapCompose — keep tile provider interface
+-dontwarn ovh.plrapps.mapcompose.**
+
+# Keep enums used in serialization/settings
+-keepclassmembers,allowoptimization enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
## Summary
- Enable `isMinifyEnabled` and `isShrinkResources` for release build type
- Add `proguard-rules.pro` with keep rules for kotlinx.serialization, Koin KSP-generated code, Ktor, and enums
- Release APK shrinks from ~11MB to ~5.7MB

## Test plan
- [x] `./gradlew :composeApp:assembleRelease` succeeds
- [x] All unit tests pass
- [x] ktlint and detekt pass
- [ ] Manual smoke test on device with release build to verify DI, serialization, and API calls work

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)