### PR TITLE
Add settings for default, min, and max zoom levels

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -135,6 +135,9 @@ android {
             )
         }
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -29,6 +29,10 @@
     <string name="show_minimap_trails_description">Display trails on the flight detail mini-map</string>
     <string name="open_urls_externally_title">Open URLs externally</string>
     <string name="open_urls_externally_description">Open aircraft and receiver URLs in an external browser</string>
+    <string name="default_zoom_level_title">Default Zoom Level</string>
+    <string name="min_zoom_level_title">Min Zoom Level</string>
+    <string name="max_zoom_level_title">Max Zoom Level</string>
+    <string name="zoom_section_title">Zoom</string>
     <string name="enable_flightaware_api_title">Enable FlightAware API</string>
     <string name="enable_flightaware_api_description">Use the FlightAware API to get more information about flights</string>
     <string name="flightaware_api_key_title">FlightAware API Key</string>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
@@ -16,6 +16,8 @@ val mapSize = mapSizeAtLevel(MAX_LEVEL, tileSize = TILE_SIZE)
 
 const val GROUND_ALTITUDE = "ground"
 
+fun scaleForZoomLevel(level: Int): Double = 1.0 / 2.0.pow(MAX_LEVEL - level)
+
 fun mapSizeAtLevel(
     wmtsLevel: Int,
     tileSize: Int,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -70,6 +70,7 @@ class MapViewModel(
     private val loadSettingsUseCase: LoadSettingsUseCase,
 ) : ViewModel() {
     private var saveStateJob: Job? = null
+    private var scaleConstraintJob: Job? = null
     private var settings: Settings? = null
     private val previousAircraftMarkerIds = mutableSetOf<String>()
     private val previousPathIds = mutableSetOf<String>()
@@ -94,6 +95,9 @@ class MapViewModel(
 
     val state =
         MapState(levelCount = MAX_LEVEL + 1, mapSize, mapSize, workerCount = 16) {
+            // Safety net: hardcoded floor so the map always has a lower bound even before
+            // settings load.  The user-configured min/max are enforced reactively by
+            // startScaleConstraintJob(), which clamps scale on every change.
             minimumScaleMode(Forced((1 / 2.0.pow(MAX_LEVEL - MIN_LEVEL))))
         }.apply {
             addLayer(mapProvider)
@@ -181,6 +185,9 @@ class MapViewModel(
         } else if (!hasAppliedInitialZoom) {
             applyDefaultZoom(settings)
         }
+        if (scaleConstraintJob == null) {
+            startScaleConstraintJob()
+        }
     }
 
     private suspend fun loadMapState(settings: Settings) {
@@ -215,6 +222,33 @@ class MapViewModel(
                             Logger.d("Saved map state $scroll, $scale")
                         }
                     }.launchIn(this)
+            }
+    }
+
+    /**
+     * Observes [state].scale in real-time and clamps it to the user-configured
+     * min/max zoom range.  Reads [settings] on every emission so that changes
+     * to the zoom-level settings take effect immediately without restarting
+     * the job.
+     *
+     * The `if (clamped != currentScale)` guard prevents an infinite loop:
+     * setting `state.scale` triggers another emission, but the clamped value
+     * will already be in-range so no further write occurs.
+     */
+    private fun startScaleConstraintJob() {
+        scaleConstraintJob =
+            viewModelScope.launch {
+                snapshotFlow { state.scale }.collect { currentScale ->
+                    val currentSettings = settings ?: return@collect
+                    val minScale = scaleForZoomLevel(currentSettings.minZoomLevel)
+                    val maxScale = scaleForZoomLevel(currentSettings.maxZoomLevel)
+                    val effectiveMin = minOf(minScale, maxScale)
+                    val effectiveMax = maxOf(minScale, maxScale)
+                    val clamped = currentScale.coerceIn(effectiveMin, effectiveMax)
+                    if (clamped != currentScale) {
+                        state.scale = clamped
+                    }
+                }
             }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -165,6 +165,8 @@ class MapViewModel(
         }
     }
 
+    private var hasAppliedInitialZoom = false
+
     private suspend fun onSettingsLoaded(settings: Settings) {
         this.settings = settings
         _showUserLocationOnMap.value = settings.showUserLocationOnMap
@@ -174,16 +176,28 @@ class MapViewModel(
         onAircraftTrailsUpdated(lastTrails)
         saveStateJob?.cancel()
         if (settings.restoreMapStateOnStart) {
-            loadMapState()
+            loadMapState(settings)
             startSaveMapStateJob()
+        } else if (!hasAppliedInitialZoom) {
+            applyDefaultZoom(settings)
         }
     }
 
-    private suspend fun loadMapState() {
+    private suspend fun loadMapState(settings: Settings) {
         val savedState = getSavedMapStateUseCase()
         Logger.d("Restored map state $savedState")
         state.setScroll(savedState.scrollX, savedState.scrollY)
-        state.scale = savedState.zoom
+        val minScale = scaleForZoomLevel(settings.minZoomLevel)
+        val maxScale = scaleForZoomLevel(settings.maxZoomLevel)
+        val effectiveMin = minOf(minScale, maxScale)
+        val effectiveMax = maxOf(minScale, maxScale)
+        state.scale = savedState.zoom.coerceIn(effectiveMin, effectiveMax)
+        hasAppliedInitialZoom = true
+    }
+
+    private fun applyDefaultZoom(settings: Settings) {
+        state.scale = scaleForZoomLevel(settings.defaultZoomLevel)
+        hasAppliedInitialZoom = true
     }
 
     private fun startSaveMapStateJob() {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -196,7 +196,11 @@ class MapViewModel(
     }
 
     private fun applyDefaultZoom(settings: Settings) {
-        state.scale = scaleForZoomLevel(settings.defaultZoomLevel)
+        val minScale = scaleForZoomLevel(settings.minZoomLevel)
+        val maxScale = scaleForZoomLevel(settings.maxZoomLevel)
+        val effectiveMin = minOf(minScale, maxScale)
+        val effectiveMax = maxOf(minScale, maxScale)
+        state.scale = scaleForZoomLevel(settings.defaultZoomLevel).coerceIn(effectiveMin, effectiveMax)
         hasAppliedInitialZoom = true
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
@@ -14,4 +14,13 @@ data class Settings(
     val openUrlsExternally: Boolean = false,
     val enableFlightAwareApi: Boolean = false,
     val flightAwareApiKey: String = "",
-)
+    val defaultZoomLevel: Int = DEFAULT_ZOOM_LEVEL,
+    val minZoomLevel: Int = MIN_ZOOM_LEVEL,
+    val maxZoomLevel: Int = MAX_ZOOM_LEVEL,
+) {
+    companion object {
+        const val MIN_ZOOM_LEVEL = 1
+        const val MAX_ZOOM_LEVEL = 16
+        const val DEFAULT_ZOOM_LEVEL = 8
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -84,4 +84,19 @@ class SettingsViewModel(
         viewModelScope.launch {
             settingsService.setFlightAwareApiKey(apiKey)
         }
+
+    fun updateDefaultZoomLevel(level: Int) =
+        viewModelScope.launch {
+            settingsService.setDefaultZoomLevel(level)
+        }
+
+    fun updateMinZoomLevel(level: Int) =
+        viewModelScope.launch {
+            settingsService.setMinZoomLevel(level)
+        }
+
+    fun updateMaxZoomLevel(level: Int) =
+        viewModelScope.launch {
+            settingsService.setMaxZoomLevel(level)
+        }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.Factory
 import kotlin.uuid.Uuid
 
+@Suppress("TooManyFunctions")
 @Factory
 class SettingsViewModel(
     private val settingsService: SettingsService,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
@@ -28,6 +28,9 @@ interface SettingsRepository {
         val OPEN_URLS_EXTERNALLY = booleanPreferencesKey("openUrlsExternally")
         val ENABLE_FLIGHT_AWARE_API = booleanPreferencesKey("enableFlightAwareApi")
         val FLIGHT_AWARE_API_KEY = stringPreferencesKey("flightAwareApiKey")
+        val DEFAULT_ZOOM_LEVEL = intPreferencesKey("defaultZoomLevel")
+        val MIN_ZOOM_LEVEL = intPreferencesKey("minZoomLevel")
+        val MAX_ZOOM_LEVEL = intPreferencesKey("maxZoomLevel")
         const val DEFAULT_REFRESH_INTERVAL = 5
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
@@ -37,6 +37,15 @@ class SettingsRepositoryImpl(
                 openUrlsExternally = preferences[SettingsRepository.OPEN_URLS_EXTERNALLY] ?: false,
                 enableFlightAwareApi = preferences[SettingsRepository.ENABLE_FLIGHT_AWARE_API] ?: false,
                 flightAwareApiKey = preferences[SettingsRepository.FLIGHT_AWARE_API_KEY] ?: "",
+                defaultZoomLevel =
+                    preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL]
+                        ?: Settings.DEFAULT_ZOOM_LEVEL,
+                minZoomLevel =
+                    preferences[SettingsRepository.MIN_ZOOM_LEVEL]
+                        ?: Settings.MIN_ZOOM_LEVEL,
+                maxZoomLevel =
+                    preferences[SettingsRepository.MAX_ZOOM_LEVEL]
+                        ?: Settings.MAX_ZOOM_LEVEL,
             )
         }
     }
@@ -54,6 +63,9 @@ class SettingsRepositoryImpl(
             preferences[SettingsRepository.OPEN_URLS_EXTERNALLY] = settings.openUrlsExternally
             preferences[SettingsRepository.ENABLE_FLIGHT_AWARE_API] = settings.enableFlightAwareApi
             preferences[SettingsRepository.FLIGHT_AWARE_API_KEY] = settings.flightAwareApiKey
+            preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL] = settings.defaultZoomLevel
+            preferences[SettingsRepository.MIN_ZOOM_LEVEL] = settings.minZoomLevel
+            preferences[SettingsRepository.MAX_ZOOM_LEVEL] = settings.maxZoomLevel
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
@@ -33,8 +33,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.SettingsViewModel
 import com.jordankurtz.piawaremobile.settings.TrailDisplayMode
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
@@ -44,10 +46,13 @@ import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.center_map_on_user_description
 import piawaremobile.composeapp.generated.resources.center_map_on_user_title
+import piawaremobile.composeapp.generated.resources.default_zoom_level_title
 import piawaremobile.composeapp.generated.resources.enable_flightaware_api_description
 import piawaremobile.composeapp.generated.resources.enable_flightaware_api_title
 import piawaremobile.composeapp.generated.resources.flightaware_api_key_title
 import piawaremobile.composeapp.generated.resources.ic_chevron_right
+import piawaremobile.composeapp.generated.resources.max_zoom_level_title
+import piawaremobile.composeapp.generated.resources.min_zoom_level_title
 import piawaremobile.composeapp.generated.resources.open_urls_externally_description
 import piawaremobile.composeapp.generated.resources.open_urls_externally_title
 import piawaremobile.composeapp.generated.resources.preferences_title
@@ -64,6 +69,7 @@ import piawaremobile.composeapp.generated.resources.show_user_location_descripti
 import piawaremobile.composeapp.generated.resources.show_user_location_title
 import piawaremobile.composeapp.generated.resources.trail_display_mode_description
 import piawaremobile.composeapp.generated.resources.trail_display_mode_title
+import piawaremobile.composeapp.generated.resources.zoom_section_title
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -87,7 +93,7 @@ fun MainScreen(
         },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier.padding(paddingValues).testTag("settings_list"),
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
             item {
@@ -133,6 +139,34 @@ fun MainScreen(
                     description = stringResource(Res.string.restore_map_position_description),
                     checked = settings.getValue()?.restoreMapStateOnStart ?: true,
                     onCheckedChange = viewModel::updateRestoreMapStateOnStart,
+                )
+            }
+
+            item {
+                SettingsSection(title = stringResource(Res.string.zoom_section_title))
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.default_zoom_level_title),
+                    value = settings.getValue()?.defaultZoomLevel ?: Settings.DEFAULT_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateDefaultZoomLevel,
+                )
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.min_zoom_level_title),
+                    value = settings.getValue()?.minZoomLevel ?: Settings.MIN_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateMinZoomLevel,
+                )
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.max_zoom_level_title),
+                    value = settings.getValue()?.maxZoomLevel ?: Settings.MAX_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateMaxZoomLevel,
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
@@ -43,4 +43,10 @@ interface SettingsService {
     suspend fun setEnableFlightAwareApi(enabled: Boolean)
 
     suspend fun setFlightAwareApiKey(apiKey: String)
+
+    suspend fun setDefaultZoomLevel(level: Int)
+
+    suspend fun setMinZoomLevel(level: Int)
+
+    suspend fun setMaxZoomLevel(level: Int)
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
@@ -111,4 +111,10 @@ class SettingsServiceImpl(
         updateSetting { it.copy(enableFlightAwareApi = enabled) }
 
     override suspend fun setFlightAwareApiKey(apiKey: String) = updateSetting { it.copy(flightAwareApiKey = apiKey) }
+
+    override suspend fun setDefaultZoomLevel(level: Int) = updateSetting { it.copy(defaultZoomLevel = level) }
+
+    override suspend fun setMinZoomLevel(level: Int) = updateSetting { it.copy(minZoomLevel = level) }
+
+    override suspend fun setMaxZoomLevel(level: Int) = updateSetting { it.copy(maxZoomLevel = level) }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapHelpersTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapHelpersTest.kt
@@ -1,6 +1,7 @@
 package com.jordankurtz.piawaremobile.map
 
 import androidx.compose.ui.graphics.Color
+import kotlin.math.pow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -185,5 +186,25 @@ class MapHelpersTest {
             )
         val result = computeFitTarget(coordinates)
         assertIs<FitTarget.BoundingRegion>(result)
+    }
+
+    // --- scaleForZoomLevel tests ---
+
+    @Test
+    fun scaleForZoomLevelAtMaxLevelReturnsOne() {
+        assertEquals(1.0, scaleForZoomLevel(MAX_LEVEL))
+    }
+
+    @Test
+    fun scaleForZoomLevelAtMinLevelReturnsMinimumScale() {
+        val expected = 1.0 / 2.0.pow((MAX_LEVEL - MIN_LEVEL).toDouble())
+        assertEquals(expected, scaleForZoomLevel(MIN_LEVEL))
+    }
+
+    @Test
+    fun scaleForZoomLevelIncreasesWithLevel() {
+        val scale5 = scaleForZoomLevel(5)
+        val scale10 = scaleForZoomLevel(10)
+        assertTrue(scale10 > scale5)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.jordankurtz.piawaremobile.map.usecase.GetSavedMapStateUseCase
@@ -447,5 +448,112 @@ class MapViewModelTest {
             val effectiveMax = maxOf(minScale, maxScale)
             assertTrue(viewModel.state.scale <= effectiveMax)
             assertTrue(viewModel.state.scale >= effectiveMin)
+        }
+
+    @Test
+    fun scaleClampedBackWhenSetAboveMaxZoom() =
+        runTest(testDispatcher) {
+            val zoomSettings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 8,
+                    minZoomLevel = 3,
+                    maxZoomLevel = 12,
+                )
+            settingsFlow = MutableStateFlow(Async.Success(zoomSettings))
+            every { loadSettingsUseCase() } returns settingsFlow
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Simulate user pinch-zooming past maxZoomLevel
+            Snapshot.withMutableSnapshot { vm.state.scale = scaleForZoomLevel(15) }
+            advanceUntilIdle()
+
+            val maxScale = scaleForZoomLevel(12)
+            assertEquals(maxScale, vm.state.scale)
+        }
+
+    @Test
+    fun scaleClampedBackWhenSetBelowMinZoom() =
+        runTest(testDispatcher) {
+            val zoomSettings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 8,
+                    minZoomLevel = 5,
+                    maxZoomLevel = 14,
+                )
+            settingsFlow = MutableStateFlow(Async.Success(zoomSettings))
+            every { loadSettingsUseCase() } returns settingsFlow
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Simulate user pinch-zooming below minZoomLevel
+            Snapshot.withMutableSnapshot { vm.state.scale = scaleForZoomLevel(2) }
+            advanceUntilIdle()
+
+            val minScale = scaleForZoomLevel(5)
+            assertEquals(minScale, vm.state.scale)
+        }
+
+    @Test
+    fun scaleConstraintUpdatesWhenSettingsChange() =
+        runTest(testDispatcher) {
+            val initialSettings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 8,
+                    minZoomLevel = 3,
+                    maxZoomLevel = 14,
+                )
+            settingsFlow = MutableStateFlow(Async.Success(initialSettings))
+            every { loadSettingsUseCase() } returns settingsFlow
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Zoom to level 12 — within initial range
+            Snapshot.withMutableSnapshot { vm.state.scale = scaleForZoomLevel(12) }
+            advanceUntilIdle()
+            assertEquals(scaleForZoomLevel(12), vm.state.scale)
+
+            // Now tighten maxZoomLevel to 10 — current scale should be clamped
+            settingsFlow.value =
+                Async.Success(
+                    initialSettings.copy(maxZoomLevel = 10),
+                )
+            advanceUntilIdle()
+
+            // Simulate user zooming slightly — any scale change triggers the
+            // snapshotFlow which now reads the tighter maxZoomLevel=10
+            Snapshot.withMutableSnapshot { vm.state.scale = scaleForZoomLevel(13) }
+            advanceUntilIdle()
+
+            assertEquals(scaleForZoomLevel(10), vm.state.scale)
+        }
+
+    @Test
+    fun scaleWithinRangeIsNotClamped() =
+        runTest(testDispatcher) {
+            val zoomSettings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 8,
+                    minZoomLevel = 3,
+                    maxZoomLevel = 14,
+                )
+            settingsFlow = MutableStateFlow(Async.Success(zoomSettings))
+            every { loadSettingsUseCase() } returns settingsFlow
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val targetScale = scaleForZoomLevel(10)
+            Snapshot.withMutableSnapshot { vm.state.scale = targetScale }
+            advanceUntilIdle()
+
+            assertEquals(targetScale, vm.state.scale)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -21,11 +21,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import ovh.plrapps.mapcompose.api.scale
 import ovh.plrapps.mapcompose.core.TileStreamProvider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -359,5 +361,91 @@ class MapViewModelTest {
             vm.followingAircraft.test {
                 assertNull(awaitItem())
             }
+        }
+
+    @Test
+    fun applyDefaultZoomClampsToMaxWhenDefaultExceedsMax() =
+        runTest {
+            val settings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 14,
+                    minZoomLevel = 3,
+                    maxZoomLevel = 10,
+                )
+            loadSettingsUseCase = mock()
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val expectedScale = scaleForZoomLevel(10)
+            assertEquals(expectedScale, viewModel.state.scale)
+        }
+
+    @Test
+    fun applyDefaultZoomClampsToMinWhenDefaultBelowMin() =
+        runTest {
+            val settings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 1,
+                    minZoomLevel = 5,
+                    maxZoomLevel = 12,
+                )
+            loadSettingsUseCase = mock()
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val expectedScale = scaleForZoomLevel(5)
+            assertEquals(expectedScale, viewModel.state.scale)
+        }
+
+    @Test
+    fun applyDefaultZoomUsesDefaultWhenWithinRange() =
+        runTest {
+            val settings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 8,
+                    minZoomLevel = 3,
+                    maxZoomLevel = 14,
+                )
+            loadSettingsUseCase = mock()
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val expectedScale = scaleForZoomLevel(8)
+            assertEquals(expectedScale, viewModel.state.scale)
+        }
+
+    @Test
+    fun applyDefaultZoomHandlesSwappedMinMax() =
+        runTest {
+            // If min > max in zoom level terms, the effective scale range should still work
+            val settings =
+                Settings(
+                    restoreMapStateOnStart = false,
+                    defaultZoomLevel = 14,
+                    minZoomLevel = 10,
+                    maxZoomLevel = 3,
+                )
+            loadSettingsUseCase = mock()
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Default 14 exceeds the effective max (zoom level 10), so should clamp
+            val minScale = scaleForZoomLevel(10)
+            val maxScale = scaleForZoomLevel(3)
+            val effectiveMin = minOf(minScale, maxScale)
+            val effectiveMax = maxOf(minScale, maxScale)
+            assertTrue(viewModel.state.scale <= effectiveMax)
+            assertTrue(viewModel.state.scale >= effectiveMin)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -97,7 +97,7 @@ class MapViewModelTest {
 
     @Test
     fun `fitToAircraft with empty list is a no-op`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.fitToAircraft(emptyList())
@@ -106,7 +106,7 @@ class MapViewModelTest {
 
     @Test
     fun `fitToAircraft with single aircraft scrolls to projected point`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             val aircraft =
@@ -121,7 +121,7 @@ class MapViewModelTest {
 
     @Test
     fun `fitToAircraft with multiple aircraft computes bounding box`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             val aircraft =
@@ -142,7 +142,7 @@ class MapViewModelTest {
 
     @Test
     fun `fitToAircraft with two aircraft at same location handles degenerate bounding box`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             val aircraft =
@@ -160,7 +160,7 @@ class MapViewModelTest {
 
     @Test
     fun `followingUserLocation starts as false`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             assertFalse(vm.followingUserLocation.value)
@@ -168,7 +168,7 @@ class MapViewModelTest {
 
     @Test
     fun `toggleFollowUserLocation flips state from false to true`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             assertFalse(vm.followingUserLocation.value)
@@ -179,7 +179,7 @@ class MapViewModelTest {
 
     @Test
     fun `toggleFollowUserLocation flips state from true to false`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
 
@@ -192,7 +192,7 @@ class MapViewModelTest {
 
     @Test
     fun `showUserLocationOnMap reflects settings value when true`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
 
@@ -201,7 +201,7 @@ class MapViewModelTest {
 
     @Test
     fun `showUserLocationOnMap reflects settings value when false`() =
-        runTest {
+        runTest(testDispatcher) {
             settingsFlow.value = Async.Success(settings.copy(showUserLocationOnMap = false))
 
             val vm = createViewModel()
@@ -212,7 +212,7 @@ class MapViewModelTest {
 
     @Test
     fun `disabling showUserLocationOnMap also disables following`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
 
@@ -228,7 +228,7 @@ class MapViewModelTest {
 
     @Test
     fun `onUserLocationChanged does not recenter when not following`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
 
@@ -241,7 +241,7 @@ class MapViewModelTest {
 
     @Test
     fun `onUserLocationChanged recenters map when following`() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
 
@@ -257,7 +257,7 @@ class MapViewModelTest {
 
     @Test
     fun followSelectedAircraftSetsFollowedHexFromSelection() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.syncSelection("ABC123")
@@ -270,7 +270,7 @@ class MapViewModelTest {
 
     @Test
     fun unfollowAircraftClearsFollowedHex() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.syncSelection("ABC123")
@@ -284,7 +284,7 @@ class MapViewModelTest {
 
     @Test
     fun onAircraftDeselectedClearsFollowedHex() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.syncSelection("ABC123")
@@ -301,7 +301,7 @@ class MapViewModelTest {
 
     @Test
     fun followedAircraftClearedWhenDisappearsFromFeed() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.syncSelection("ABC123")
@@ -327,7 +327,7 @@ class MapViewModelTest {
 
     @Test
     fun followedAircraftNotClearedWhenStillInFeed() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.syncSelection("ABC123")
@@ -353,7 +353,7 @@ class MapViewModelTest {
 
     @Test
     fun followSelectedAircraftWithNoSelectionSetsNull() =
-        runTest {
+        runTest(testDispatcher) {
             val vm = createViewModel()
             advanceUntilIdle()
             vm.followSelectedAircraft()
@@ -365,7 +365,7 @@ class MapViewModelTest {
 
     @Test
     fun applyDefaultZoomClampsToMaxWhenDefaultExceedsMax() =
-        runTest {
+        runTest(testDispatcher) {
             val settings =
                 Settings(
                     restoreMapStateOnStart = false,
@@ -385,7 +385,7 @@ class MapViewModelTest {
 
     @Test
     fun applyDefaultZoomClampsToMinWhenDefaultBelowMin() =
-        runTest {
+        runTest(testDispatcher) {
             val settings =
                 Settings(
                     restoreMapStateOnStart = false,
@@ -405,7 +405,7 @@ class MapViewModelTest {
 
     @Test
     fun applyDefaultZoomUsesDefaultWhenWithinRange() =
-        runTest {
+        runTest(testDispatcher) {
             val settings =
                 Settings(
                     restoreMapStateOnStart = false,
@@ -425,7 +425,7 @@ class MapViewModelTest {
 
     @Test
     fun applyDefaultZoomHandlesSwappedMinMax() =
-        runTest {
+        runTest(testDispatcher) {
             // If min > max in zoom level terms, the effective scale range should still work
             val settings =
                 Settings(

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModelTest.kt
@@ -62,6 +62,9 @@ class SettingsViewModelTest {
         everySuspend { settingsService.setOpenUrlsExternally(any()) } returns Unit
         everySuspend { settingsService.setEnableFlightAwareApi(any()) } returns Unit
         everySuspend { settingsService.setFlightAwareApiKey(any()) } returns Unit
+        everySuspend { settingsService.setDefaultZoomLevel(any()) } returns Unit
+        everySuspend { settingsService.setMinZoomLevel(any()) } returns Unit
+        everySuspend { settingsService.setMaxZoomLevel(any()) } returns Unit
 
         viewModel = SettingsViewModel(settingsService)
     }
@@ -177,5 +180,32 @@ class SettingsViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setOpenUrlsExternally(true) }
+        }
+
+    @Test
+    fun `updateDefaultZoomLevel delegates to settings service`() =
+        runTest {
+            viewModel.updateDefaultZoomLevel(10)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setDefaultZoomLevel(10) }
+        }
+
+    @Test
+    fun `updateMinZoomLevel delegates to settings service`() =
+        runTest {
+            viewModel.updateMinZoomLevel(3)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setMinZoomLevel(3) }
+        }
+
+    @Test
+    fun `updateMaxZoomLevel delegates to settings service`() =
+        runTest {
+            viewModel.updateMaxZoomLevel(14)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setMaxZoomLevel(14) }
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsServiceImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsServiceImplTest.kt
@@ -282,4 +282,82 @@ class SettingsServiceImplTest {
             val flow = settingsService.loadSettings()
             assertNotNull(flow)
         }
+
+    // Zoom level tests
+
+    @Test
+    fun `setDefaultZoomLevel saves updated value`() =
+        runTest(testDispatcher) {
+            mockSettings()
+            val slot = captureSettings()
+
+            settingsService.setDefaultZoomLevel(10)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(10, saved.defaultZoomLevel)
+        }
+
+    @Test
+    fun `setMinZoomLevel saves updated value`() =
+        runTest(testDispatcher) {
+            mockSettings()
+            val slot = captureSettings()
+
+            settingsService.setMinZoomLevel(3)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(3, saved.minZoomLevel)
+        }
+
+    @Test
+    fun `setMaxZoomLevel saves updated value`() =
+        runTest(testDispatcher) {
+            mockSettings()
+            val slot = captureSettings()
+
+            settingsService.setMaxZoomLevel(14)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(14, saved.maxZoomLevel)
+        }
+
+    @Test
+    fun `setDefaultZoomLevel preserves other settings`() =
+        runTest(testDispatcher) {
+            val customSettings = defaultSettings.copy(refreshInterval = 15, minZoomLevel = 2, maxZoomLevel = 12)
+            mockSettings(customSettings)
+            val slot = captureSettings()
+
+            settingsService.setDefaultZoomLevel(7)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(7, saved.defaultZoomLevel)
+            assertEquals(15, saved.refreshInterval)
+            assertEquals(2, saved.minZoomLevel)
+            assertEquals(12, saved.maxZoomLevel)
+        }
+
+    @Test
+    fun `setMinZoomLevel at boundary value`() =
+        runTest(testDispatcher) {
+            mockSettings()
+            val slot = captureSettings()
+
+            settingsService.setMinZoomLevel(1)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(1, saved.minZoomLevel)
+        }
+
+    @Test
+    fun `setMaxZoomLevel at boundary value`() =
+        runTest(testDispatcher) {
+            mockSettings()
+            val slot = captureSettings()
+
+            settingsService.setMaxZoomLevel(16)
+
+            val saved = (slot.value as SlotCapture.Value.Present).value
+            assertEquals(16, saved.maxZoomLevel)
+        }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
@@ -22,6 +22,9 @@ fun mockSettings(
     openUrlsExternally: Boolean = false,
     enableFlightAwareApi: Boolean = false,
     flightAwareApiKey: String = "",
+    defaultZoomLevel: Int = Settings.DEFAULT_ZOOM_LEVEL,
+    minZoomLevel: Int = Settings.MIN_ZOOM_LEVEL,
+    maxZoomLevel: Int = Settings.MAX_ZOOM_LEVEL,
 ): Settings =
     Settings(
         servers = servers,
@@ -35,6 +38,9 @@ fun mockSettings(
         openUrlsExternally = openUrlsExternally,
         enableFlightAwareApi = enableFlightAwareApi,
         flightAwareApiKey = flightAwareApiKey,
+        defaultZoomLevel = defaultZoomLevel,
+        minZoomLevel = minZoomLevel,
+        maxZoomLevel = maxZoomLevel,
     )
 
 fun mockServer(

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
@@ -2,8 +2,11 @@ package com.jordankurtz.piawaremobile.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.runComposeUiTest
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.Settings
@@ -63,11 +66,14 @@ class SettingsScreenTest {
             setContent {
                 MainScreen(onServersClicked = {}, viewModel = createViewModel())
             }
-            onNodeWithText("Show receiver locations").assertIsDisplayed()
-            onNodeWithText("Show User Location on Map").assertIsDisplayed()
-            onNodeWithText("Show Minimap Trails").assertIsDisplayed()
             onNodeWithText("Center map on user").assertIsDisplayed()
             onNodeWithText("Restore map position").assertIsDisplayed()
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Show receiver locations"))
+            onNodeWithText("Show receiver locations").assertIsDisplayed()
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Show User Location on Map"))
+            onNodeWithText("Show User Location on Map").assertIsDisplayed()
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Show Minimap Trails"))
+            onNodeWithText("Show Minimap Trails").assertIsDisplayed()
         }
 
     @Test
@@ -94,6 +100,21 @@ class SettingsScreenTest {
             setContent {
                 MainScreen(onServersClicked = {}, viewModel = createViewModel())
             }
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Enable FlightAware API"))
             onNodeWithText("Enable FlightAware API").assertIsDisplayed()
+        }
+
+    @Test
+    fun displaysZoomSettings() =
+        runComposeUiTest {
+            setContent {
+                MainScreen(onServersClicked = {}, viewModel = createViewModel())
+            }
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Default Zoom Level"))
+            onNodeWithText("Default Zoom Level").assertIsDisplayed()
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Min Zoom Level"))
+            onNodeWithText("Min Zoom Level").assertIsDisplayed()
+            onNodeWithTag("settings_list").performScrollToNode(hasText("Max Zoom Level"))
+            onNodeWithText("Max Zoom Level").assertIsDisplayed()
         }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ sentry = "0.23.0"
 ktlint-plugin = "12.2.0"
 detekt = "1.23.8"
 kover = "0.9.1"
-androidx-compose-ui-test = "1.9.3"
+androidx-compose-ui-test = "1.10.5"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Add `defaultZoomLevel`, `minZoomLevel`, `maxZoomLevel` settings (integers 1-16)
- New "Zoom" section in settings UI between "Restore map position" and "Show receiver locations"
- MapViewModel applies default zoom when "Restore map position" is off, clamps restored zoom to [min, max] when on
- New `scaleForZoomLevel()` helper converts WMTS levels to MapCompose scale factors

## Test plan
- [x] Unit tests pass (`MapHelpersTest`, `SettingsViewModelTest`, `SettingsRepositoryImplTest`)
- [x] Desktop UI tests pass (new `displaysZoomSettings` test, existing tests updated for scroll)
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew detekt` passes
- [ ] Manual verification that zoom settings take effect on the map

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)