### PR TITLE
Add dark mode support with CartoDB Dark Matter tiles

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="planes_count">%1$d planes</string>
     <!--    <string name="planes_count">planes</string>-->
     <string name="openstreetmap_copyright">© OpenStreetMap contributors</string>
+    <string name="cartodb_copyright">© CartoDB © OpenStreetMap contributors</string>
     <string name="user_location_content_description">User Location</string>
     <string name="fit_to_aircraft">Fit map to aircraft</string>
     <string name="follow_aircraft">Follow</string>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/Overlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/Overlay.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
 import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.cartodb_copyright
 import piawaremobile.composeapp.generated.resources.openstreetmap_copyright
 import piawaremobile.composeapp.generated.resources.planes_count
 
 @Composable
 fun Overlay(
     numberOfPlanes: Int,
+    isDarkTheme: Boolean = false,
     modifier: Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -34,11 +36,23 @@ fun Overlay(
             style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
         )
 
+        val copyrightText =
+            if (isDarkTheme) {
+                stringResource(Res.string.cartodb_copyright)
+            } else {
+                stringResource(Res.string.openstreetmap_copyright)
+            }
+        val copyrightUrl =
+            if (isDarkTheme) {
+                "https://carto.com/attributions"
+            } else {
+                "https://www.openstreetmap.org/copyright"
+            }
         val annotatedString =
             buildAnnotatedString {
                 withStyle(style = SpanStyle(fontSize = 12.sp)) {
-                    pushLink(LinkAnnotation.Url("https://www.openstreetmap.org/copyright"))
-                    append(stringResource(Res.string.openstreetmap_copyright))
+                    pushLink(LinkAnnotation.Url(copyrightUrl))
+                    append(copyrightText)
                     pop()
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -22,6 +23,7 @@ import com.jordankurtz.piawaremobile.aircraft.AircraftViewModel
 import com.jordankurtz.piawaremobile.location.LocationViewModel
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.fit_to_aircraft
@@ -34,6 +36,12 @@ fun MapScreen(
     locationViewModel: LocationViewModel = koinViewModel(),
     aircraftViewModel: AircraftViewModel = koinViewModel(),
 ) {
+    val tileProvider = koinInject<OpenStreetMapProvider>()
+    val isDarkTheme = isSystemInDarkTheme()
+    LaunchedEffect(isDarkTheme) {
+        tileProvider.useDarkTiles = isDarkTheme
+    }
+
     val aircraft by aircraftViewModel.aircraft.collectAsState()
     val receiverLocations by aircraftViewModel.receiverLocations.collectAsState()
     val currentLocation by locationViewModel.currentLocation.collectAsState()
@@ -97,6 +105,7 @@ fun MapScreen(
         }
         Overlay(
             numberOfPlanes,
+            isDarkTheme = isDarkTheme,
             modifier = Modifier.align(Alignment.BottomEnd).padding(horizontal = 8.dp),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/OpenStreetMapProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/OpenStreetMapProvider.kt
@@ -8,13 +8,21 @@ import ovh.plrapps.mapcompose.core.TileStreamProvider
 
 @Single(binds = [TileStreamProvider::class])
 class OpenStreetMapProvider(private val httpClient: HttpClient) : TileStreamProvider {
+    var useDarkTiles: Boolean = false
+
     override suspend fun getTileStream(
         row: Int,
         col: Int,
         zoomLvl: Int,
     ): RawSource? {
+        val baseUrl =
+            if (useDarkTiles) {
+                "https://basemaps.cartocdn.com/dark_all/$zoomLvl/$col/$row.png"
+            } else {
+                "https://tile.openstreetmap.org/$zoomLvl/$col/$row.png"
+            }
         return try {
-            getStream(httpClient, "https://tile.openstreetmap.org/$zoomLvl/$col/$row.png")
+            getStream(httpClient, baseUrl)
         } catch (e: Exception) {
             Logger.e("Failed to load tile", e)
             null

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/Colors.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/Colors.kt
@@ -1,10 +1,17 @@
 package com.jordankurtz.piawaremobile.ui
 
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
 internal val LightColorScheme =
     lightColorScheme(
+        primary = Color(0xFF2596be),
+        onPrimary = Color.White,
+    )
+
+internal val DarkColorScheme =
+    darkColorScheme(
         primary = Color(0xFF2596be),
         onPrimary = Color.White,
     )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/Theme.kt
@@ -6,12 +6,10 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun Theme(
-    // Checks if your system is in dark theme mode.
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    // it would be nice to have a dark mode but we don't currently have dark map tiles
-    val colorScheme = if (!darkTheme) LightColorScheme else LightColorScheme
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
     MaterialTheme(
         colorScheme = colorScheme,
         content = content,


### PR DESCRIPTION
## Summary
- Enables system dark mode detection — app now respects device dark/light preference
- Adds Material3 `DarkColorScheme` alongside existing `LightColorScheme`
- Switches map tiles to CartoDB Dark Matter (`basemaps.cartocdn.com/dark_all`) in dark mode
- Updates overlay copyright attribution to show CartoDB credit when using dark tiles
- The `OpenStreetMapProvider` singleton holds a `useDarkTiles` flag set from MapScreen based on system theme

Closes #29

## Test plan
- [ ] Enable system dark mode — app UI switches to dark theme
- [ ] Map tiles load as dark-styled CartoDB tiles
- [ ] Copyright shows "CartoDB" attribution in dark mode
- [ ] Switch back to light mode — standard OSM tiles and attribution return
- [ ] MiniMap in flight details also uses dark tiles in dark mode
- [ ] Verify aircraft marker colors remain visible on dark tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)