### PR TITLE
Enable Ktor HttpCache for HTTP response caching

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.android.kt
@@ -3,6 +3,7 @@ package com.jordankurtz.piawaremobile
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -20,6 +21,7 @@ actual fun getKtorClient(): HttpClient {
                 },
             )
         }
+        install(HttpCache)
         install(HttpTimeout) {
             requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
             connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.desktop.kt
@@ -3,6 +3,7 @@ package com.jordankurtz.piawaremobile
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -20,6 +21,7 @@ actual fun getKtorClient(): HttpClient {
                 },
             )
         }
+        install(HttpCache)
         install(HttpTimeout) {
             requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
             connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/KtorClient.ios.kt
@@ -3,6 +3,7 @@ package com.jordankurtz.piawaremobile
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -20,6 +21,7 @@ actual fun getKtorClient(): HttpClient {
                 },
             )
         }
+        install(HttpCache)
         install(HttpTimeout) {
             requestTimeoutMillis = HttpTimeoutDefaults.REQUEST_TIMEOUT_MS
             connectTimeoutMillis = HttpTimeoutDefaults.CONNECT_TIMEOUT_MS


### PR DESCRIPTION
## Summary
- Installs Ktor's `HttpCache` plugin on all three platform HTTP clients (Android, iOS, Desktop)
- Provides automatic in-memory response caching that respects HTTP `Cache-Control`, `ETag`, and `Last-Modified` headers
- Reduces redundant network calls for static data like aircraft type lookups and aircraft info DB queries
- No new dependencies required — `HttpCache` is part of `ktor-client-core`

Closes #70

## Test plan
- [ ] Verify aircraft type lookups are cached (check network logs)
- [ ] Verify aircraft info DB queries use cached responses
- [ ] Confirm live data (aircraft.json) is not stale-cached
- [ ] Test on all platforms (Android, iOS, Desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)