### PR TITLE
Fix InteractiveUiTest compilation break on main

### DIFF
--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/InteractiveUiTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/InteractiveUiTest.kt
@@ -13,20 +13,7 @@ import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.SettingsViewModel
 import com.jordankurtz.piawaremobile.settings.ui.AddServerDialog
 import com.jordankurtz.piawaremobile.settings.ui.ServersScreen
-import com.jordankurtz.piawaremobile.settings.usecase.AddServerUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.DeleteServerUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.EditServerUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetCenterMapOnUserOnStartUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetEnableFlightAwareApiUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetFlightAwareApiKeyUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetOpenUrlsExternallyUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetRefreshIntervalUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetRestoreMapStateOnStartUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetShowMinimapTrailsUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetShowReceiverLocationsUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetShowUserLocationOnMapUseCase
-import com.jordankurtz.piawaremobile.settings.usecase.SetTrailDisplayModeUseCase
+import com.jordankurtz.piawaremobile.settings.usecase.SettingsService
 import com.jordankurtz.piawaremobile.testutil.mockServer
 import com.jordankurtz.piawaremobile.testutil.mockSettings
 import dev.mokkery.answering.returns
@@ -40,26 +27,13 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class InteractiveUiTest {
     private fun createViewModel(settings: Settings = mockSettings()): SettingsViewModel {
-        val loadSettingsUseCase =
-            mock<LoadSettingsUseCase> {
-                every { invoke() } returns flowOf(Async.Success(settings))
+        val settingsService =
+            mock<SettingsService> {
+                every { loadSettings() } returns flowOf(Async.Success(settings))
             }
 
         return SettingsViewModel(
-            loadSettingsUseCase = loadSettingsUseCase,
-            addServerUseCase = mock<AddServerUseCase>(),
-            editServerUseCase = mock<EditServerUseCase>(),
-            deleteServerUseCase = mock<DeleteServerUseCase>(),
-            setRefreshIntervalUseCase = mock<SetRefreshIntervalUseCase>(),
-            setCenterMapOnUserOnStartUseCase = mock<SetCenterMapOnUserOnStartUseCase>(),
-            setRestoreMapStateOnStartUseCase = mock<SetRestoreMapStateOnStartUseCase>(),
-            setShowReceiverLocationsUseCase = mock<SetShowReceiverLocationsUseCase>(),
-            setShowUserLocationOnMapUseCase = mock<SetShowUserLocationOnMapUseCase>(),
-            setTrailDisplayModeUseCase = mock<SetTrailDisplayModeUseCase>(),
-            setShowMinimapTrailsUseCase = mock<SetShowMinimapTrailsUseCase>(),
-            setOpenUrlsExternallyUseCase = mock<SetOpenUrlsExternallyUseCase>(),
-            setEnableFlightAwareApiUseCase = mock<SetEnableFlightAwareApiUseCase>(),
-            setFlightAwareApiKeyUseCase = mock<SetFlightAwareApiKeyUseCase>(),
+            settingsService = settingsService,
         )
     }
 


### PR DESCRIPTION
## Summary
- PR #102 merged `InteractiveUiTest` referencing 15 individual settings use case interfaces, but PR #91 had already consolidated them into `SettingsService`
- Replace all old use case imports and mocks with a single `SettingsService` mock
- Net reduction of 26 lines

## Test plan
- [x] `./gradlew :composeApp:compileTestKotlinDesktop` compiles
- [x] `./gradlew :composeApp:desktopTest` all tests pass
- [x] `./gradlew ktlintCheck` clean

Closes the compilation break on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)