### PR TITLE
Fix flaky MapStateRepositoryImplTest by cleaning up MapViewModelTest

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.lifecycle.viewModelScope
 import com.jordankurtz.piawaremobile.map.usecase.GetSavedMapStateUseCase
 import com.jordankurtz.piawaremobile.map.usecase.SaveMapStateUseCase
 import com.jordankurtz.piawaremobile.model.Aircraft
@@ -12,6 +13,7 @@ import dev.mokkery.every
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -62,6 +64,8 @@ class MapViewModelTest {
 
     @AfterTest
     fun tearDown() {
+        viewModel.state.shutdown()
+        viewModel.viewModelScope.cancel()
         Dispatchers.resetMain()
     }
 


### PR DESCRIPTION
## Summary

- Add proper `@AfterTest` cleanup to `MapViewModelTest` to prevent coroutine leaks that cause `UncaughtExceptionsBeforeTest` in `MapStateRepositoryImplTest`
- Call `state.shutdown()` to stop MapCompose's internal tile-loading workers before they can leak exceptions into subsequent test classes
- Cancel `viewModelScope` to stop the ViewModel's own coroutines

## Root cause

The `UncaughtExceptionsBeforeTest` error at `MapStateRepositoryImplTest.kt:39` was NOT caused by `MapStateRepositoryImpl` or its test. It was caused by **leaked coroutines from `MapViewModelTest`**, which runs earlier in the test suite.

`MapViewModelTest` creates a `MapViewModel` which constructs a MapCompose `MapState(workerCount = 16)`. This spawns 16 tile-loading worker coroutines on MapCompose's internal `CoroutineScope` (using `Dispatchers.Default`, not the test dispatcher). When the test ends without shutting down these workers, they continue running and can throw exceptions that get captured by the global uncaught exception handler. The next `runTest` call (in `MapStateRepositoryImplTest`) detects these leaked exceptions and fails with `UncaughtExceptionsBeforeTest`.

This was timing-dependent -- it passed locally (fast machine) but failed on CI (slower GitHub Actions runner) because the worker coroutines had more time to throw before being garbage collected.

PR #105 correctly migrated away from `DataStoreSettings` but didn't address this root cause because the leak originated in a different test class entirely.

## Test plan

- [x] `ktlintCheck` passes
- [x] `detekt` passes
- [x] `testDebugUnitTest` passes (all 175 tests)
- [x] `desktopTest` passes
- [ ] CI pipeline passes (the real validation -- this test only fails on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)