### PR TITLE
Fix flaky Android unit tests by moving MapViewModelTest to desktopTest

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -135,6 +135,9 @@ android {
             )
         }
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -37,6 +37,9 @@ import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class MapViewModelTest {
+    // Runs in desktopTest because MapCompose's MapState requires a working Compose runtime
+    // and snapshot system. Android JVM unit tests lack a Looper, causing snapshot coroutines
+    // to leak IllegalStateException via HandlerDispatcher when Dispatchers.Main is reset.
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var mapProvider: TileStreamProvider


### PR DESCRIPTION
## Summary

- Move `MapViewModelTest` from `commonTest` to `desktopTest` to avoid Android JVM Looper/HandlerDispatcher failures during snapshot coroutine teardown
- Add `testOptions { unitTests.isReturnDefaultValues = true }` to the android block for remaining Android unit tests
- Create follow-up issue #109 for the long-term fix (abstracting MapState behind an interface)

## Test plan

- [ ] `./gradlew :composeApp:testDebugUnitTest` passes (no MapViewModelTest, no leaked exceptions into MapStateRepositoryImplTest)
- [ ] `./gradlew :composeApp:desktopTest` passes (MapViewModelTest runs here now, all 20 tests pass)
- [ ] `./gradlew ktlintCheck` passes
- [ ] `./gradlew detekt` passes
- [ ] CI green on both phone and tablet emulator profiles

Closes the Android unit test CI failures on main.
Related: #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)