### PR TITLE
Cancel follow-user-location on map touch

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -41,6 +41,7 @@ import ovh.plrapps.mapcompose.api.addMarker
 import ovh.plrapps.mapcompose.api.addPath
 import ovh.plrapps.mapcompose.api.onMarkerClick
 import ovh.plrapps.mapcompose.api.onTap
+import ovh.plrapps.mapcompose.api.onTouchDown
 import ovh.plrapps.mapcompose.api.removeMarker
 import ovh.plrapps.mapcompose.api.removePath
 import ovh.plrapps.mapcompose.api.scale
@@ -116,6 +117,8 @@ class MapViewModel(
                     onAircraftTrailsUpdated(lastTrails)
                 }
             }
+
+            onTouchDown { onMapTouchDown() }
         }
 
     init {
@@ -262,6 +265,12 @@ class MapViewModel(
 
     fun toggleFollowUserLocation() {
         _followingUserLocation.value = !_followingUserLocation.value
+    }
+
+    internal fun onMapTouchDown() {
+        if (_followingUserLocation.value) {
+            _followingUserLocation.value = false
+        }
     }
 
     fun onUserLocationChanged(location: Location) {

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -363,4 +363,27 @@ class MapViewModelTest {
                 assertNull(awaitItem())
             }
         }
+
+    @Test
+    fun `onMapTouchDown cancels follow user location when following`() =
+        runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.toggleFollowUserLocation()
+            assertTrue(vm.followingUserLocation.value)
+
+            vm.onMapTouchDown()
+            assertFalse(vm.followingUserLocation.value)
+        }
+
+    @Test
+    fun `onMapTouchDown does nothing when not following`() =
+        runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+            assertFalse(vm.followingUserLocation.value)
+
+            vm.onMapTouchDown()
+            assertFalse(vm.followingUserLocation.value)
+        }
 }


### PR DESCRIPTION
## Summary
- Register `onTouchDown` callback on `MapState` to cancel follow-user-location mode when the user interacts with the map (pan, zoom, or tap)
- Extract cancellation logic into `internal fun onMapTouchDown()` for testability
- Add two desktop tests covering the active and inactive follow-mode cases

Closes #104

## Test plan
- [ ] Enable follow-user-location, then pan the map — follow mode should deactivate
- [ ] Enable follow-user-location, then pinch-to-zoom — follow mode should deactivate
- [ ] Tap the map while following — follow mode should deactivate
- [ ] Verify the follow-location button visual state updates when follow is cancelled
- [ ] Verify that toggling follow back on after cancellation works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)