### PR TITLE
Add offline maps UI with region list, download dialog, and map indicator

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
@@ -1,0 +1,49 @@
+package com.jordankurtz.piawaremobile
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
+import com.jordankurtz.piawaremobile.settings.ui.OfflineRegion
+import org.junit.Rule
+import org.junit.Test
+
+class OfflineMapsScreenAndroidTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun offlineMapsScreenRendersEmptyState() {
+        composeTestRule.setContent {
+            OfflineMapsScreen(
+                onBack = {},
+                regions = emptyList(),
+            )
+        }
+        composeTestRule.onNodeWithText("Offline Maps").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No offline regions").assertIsDisplayed()
+    }
+
+    @Test
+    fun offlineMapsScreenRendersWithRegions() {
+        val regions =
+            listOf(
+                OfflineRegion(
+                    id = "1",
+                    name = "Test Region",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    storageSizeMb = 50,
+                    downloadDate = "2026-03-01",
+                ),
+            )
+        composeTestRule.setContent {
+            OfflineMapsScreen(
+                onBack = {},
+                regions = regions,
+            )
+        }
+        composeTestRule.onNodeWithText("Test Region").assertIsDisplayed()
+        composeTestRule.onNodeWithText("50 MB").assertIsDisplayed()
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
@@ -3,8 +3,8 @@ package com.jordankurtz.piawaremobile
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
-import com.jordankurtz.piawaremobile.settings.ui.OfflineRegion
 import org.junit.Rule
 import org.junit.Test
 

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -1,0 +1,21 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class MapRegionPickerScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun pickerRendersConfirmAndCancelButtons() {
+        composeTestRule.setContent {
+            MapRegionPickerContent(onRegionSelected = {}, onDismiss = {}, mapLayer = {})
+        }
+        composeTestRule.onNodeWithText("Confirm", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel", substring = true).assertIsDisplayed()
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -2,6 +2,7 @@ package com.jordankurtz.piawaremobile.map.offline
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import org.junit.Rule
 import org.junit.Test
@@ -17,5 +18,13 @@ class MapRegionPickerScreenTest {
         }
         composeTestRule.onNodeWithText("Confirm", substring = true).assertIsDisplayed()
         composeTestRule.onNodeWithText("Cancel", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun modeToggleButtonRendersInDefaultBoxMode() {
+        composeTestRule.setContent {
+            MapRegionPickerContent(onRegionSelected = {}, onDismiss = {}, mapLayer = {})
+        }
+        composeTestRule.onNodeWithContentDescription("Switch to map mode").assertIsDisplayed()
     }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -1,0 +1,32 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class DownloadRegionDialogTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun downloadRegionDialogRendersElements() {
+        composeTestRule.setContent {
+            DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+        }
+        composeTestRule.onNodeWithText("Download Region").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Region name").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Download").assertIsDisplayed()
+    }
+
+    @Test
+    fun downloadButtonDisabledWhenNameBlank() {
+        composeTestRule.setContent {
+            DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+        }
+        composeTestRule.onNodeWithText("Download").assertIsNotEnabled()
+    }
+}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -153,5 +153,9 @@
     <string name="offline_maps_dialog_bounds_label">Selected bounds: %1$s, %2$s – %3$s, %4$s</string>
     <string name="offline_maps_picker_confirm">Confirm</string>
     <string name="offline_maps_picker_cancel">Cancel</string>
+    <string name="offline_maps_picker_mode_map">Moving map</string>
+    <string name="offline_maps_picker_mode_box">Editing region</string>
+    <string name="offline_maps_picker_switch_to_map_mode">Switch to map mode</string>
+    <string name="offline_maps_picker_switch_to_box_mode">Switch to box mode</string>
     <string name="offline_indicator_label">Offline</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -149,5 +149,9 @@
     <string name="offline_maps_dialog_estimate">Estimated size depends on zoom levels and area</string>
     <string name="offline_maps_dialog_cancel">Cancel</string>
     <string name="offline_maps_dialog_download">Download</string>
+    <string name="offline_maps_dialog_select_on_map">Select on map</string>
+    <string name="offline_maps_dialog_bounds_label">Selected bounds: %1$s, %2$s – %3$s, %4$s</string>
+    <string name="offline_maps_picker_confirm">Confirm</string>
+    <string name="offline_maps_picker_cancel">Cancel</string>
     <string name="offline_indicator_label">Offline</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -132,4 +132,22 @@
     <string name="value_last_seen_seconds">%1$s s ago</string>
     <string name="value_location_coords">(%1$s, %2$s)</string>
     <string name="value_direction_with_cardinal">%1$d° %2$s</string>
+
+    <!-- Offline Maps -->
+    <string name="offline_maps_title">Offline Maps</string>
+    <string name="offline_maps_settings_title">Offline Maps</string>
+    <string name="offline_maps_empty_title">No offline regions</string>
+    <string name="offline_maps_empty_message">Tap + to download a map region for offline use</string>
+    <string name="offline_maps_add_region">Add region</string>
+    <string name="offline_maps_region_delete">Delete region</string>
+    <string name="offline_maps_region_zoom">Zoom %1$d – %2$d</string>
+    <string name="offline_maps_region_size">%1$d MB</string>
+    <string name="offline_maps_dialog_title">Download Region</string>
+    <string name="offline_maps_dialog_name_label">Region name</string>
+    <string name="offline_maps_dialog_min_zoom">Min zoom: %1$d</string>
+    <string name="offline_maps_dialog_max_zoom">Max zoom: %1$d</string>
+    <string name="offline_maps_dialog_estimate">Estimated size depends on zoom levels and area</string>
+    <string name="offline_maps_dialog_cancel">Cancel</string>
+    <string name="offline_maps_dialog_download">Download</string>
+    <string name="offline_indicator_label">Offline</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
@@ -1,5 +1,8 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -113,6 +116,14 @@ fun MapScreen(
                     onClick = { mapViewModel.toggleFollowUserLocation() },
                 )
             }
+        }
+        AnimatedVisibility(
+            visible = false,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.TopStart).padding(16.dp),
+        ) {
+            OfflineIndicator()
         }
         Overlay(
             numberOfPlanes,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/OfflineIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/OfflineIndicator.kt
@@ -1,0 +1,30 @@
+package com.jordankurtz.piawaremobile.map
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.offline_indicator_label
+
+@Composable
+fun OfflineIndicator(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
+        shadowElevation = 2.dp,
+    ) {
+        Text(
+            text = stringResource(Res.string.offline_indicator_label),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/BoundingBox.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/BoundingBox.kt
@@ -1,0 +1,8 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+data class BoundingBox(
+    val minLat: Double,
+    val maxLat: Double,
+    val minLon: Double,
+    val maxLon: Double,
+)

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -1,7 +1,6 @@
 package com.jordankurtz.piawaremobile.map.offline
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +15,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -26,6 +24,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
@@ -68,11 +67,7 @@ internal fun MapRegionPickerContent(
     onDismiss: () -> Unit,
     mapLayer: @Composable () -> Unit = {},
 ) {
-    var boxLeft by remember { mutableFloatStateOf(0f) }
-    var boxTop by remember { mutableFloatStateOf(0f) }
-    var boxRight by remember { mutableFloatStateOf(0f) }
-    var boxBottom by remember { mutableFloatStateOf(0f) }
-
+    var bounds by remember { mutableStateOf(BoxBounds(0f, 0f, 0f, 0f)) }
     var initialized by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -87,10 +82,13 @@ internal fun MapRegionPickerContent(
                         val h = size.toSize().height
                         if (!initialized && w > 0f && h > 0f) {
                             val margin = (1f - INITIAL_BOX_FRACTION) / 2f
-                            boxLeft = w * margin
-                            boxTop = h * margin
-                            boxRight = w * (1f - margin)
-                            boxBottom = h * (1f - margin)
+                            bounds =
+                                BoxBounds(
+                                    left = w * margin,
+                                    top = h * margin,
+                                    right = w * (1f - margin),
+                                    bottom = h * (1f - margin),
+                                )
                             initialized = true
                         }
                     }
@@ -98,62 +96,64 @@ internal fun MapRegionPickerContent(
                         val minSidePx = MIN_SIDE_LENGTH_DP.toPx()
                         val hitPx = HANDLE_HIT_TARGET_DP.toPx()
 
-                        detectDragGestures { change, dragAmount ->
-                            change.consume()
-                            val x = change.position.x - dragAmount.x
-                            val y = change.position.y - dragAmount.y
-                            val dx = dragAmount.x
-                            val dy = dragAmount.y
+                        // Track which handle is being dragged and the last pointer position so we
+                        // can compute deltas across move events.
+                        var activeHandle: HandleType? = null
+                        var lastPosition: Offset = Offset.Zero
 
-                            val midX = (boxLeft + boxRight) / 2f
-                            val midY = (boxTop + boxBottom) / 2f
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                val change = event.changes.firstOrNull() ?: continue
+                                val position = change.position
 
-                            val handlePositions =
-                                listOf(
-                                    Offset(boxLeft, boxTop) to HandleType.CORNER_TL,
-                                    Offset(boxRight, boxTop) to HandleType.CORNER_TR,
-                                    Offset(boxLeft, boxBottom) to HandleType.CORNER_BL,
-                                    Offset(boxRight, boxBottom) to HandleType.CORNER_BR,
-                                    Offset(midX, boxTop) to HandleType.EDGE_TOP,
-                                    Offset(midX, boxBottom) to HandleType.EDGE_BOTTOM,
-                                    Offset(boxLeft, midY) to HandleType.EDGE_LEFT,
-                                    Offset(boxRight, midY) to HandleType.EDGE_RIGHT,
-                                )
+                                val midX = (bounds.left + bounds.right) / 2f
+                                val midY = (bounds.top + bounds.bottom) / 2f
 
-                            val hit =
-                                handlePositions.firstOrNull { (pos, _) ->
-                                    abs(x - pos.x) < hitPx && abs(y - pos.y) < hitPx
-                                }
+                                val handlePositions =
+                                    listOf(
+                                        Offset(bounds.left, bounds.top) to HandleType.CORNER_TL,
+                                        Offset(bounds.right, bounds.top) to HandleType.CORNER_TR,
+                                        Offset(bounds.left, bounds.bottom) to HandleType.CORNER_BL,
+                                        Offset(bounds.right, bounds.bottom) to HandleType.CORNER_BR,
+                                        Offset(midX, bounds.top) to HandleType.EDGE_TOP,
+                                        Offset(midX, bounds.bottom) to HandleType.EDGE_BOTTOM,
+                                        Offset(bounds.left, midY) to HandleType.EDGE_LEFT,
+                                        Offset(bounds.right, midY) to HandleType.EDGE_RIGHT,
+                                    )
 
-                            if (hit != null) {
-                                when (hit.second) {
-                                    HandleType.CORNER_TL -> {
-                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
-                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
+                                when {
+                                    // Pointer down — check if it lands on a handle.
+                                    change.pressed && !change.previousPressed -> {
+                                        val hit =
+                                            handlePositions.firstOrNull { (pos, _) ->
+                                                abs(position.x - pos.x) < hitPx &&
+                                                    abs(position.y - pos.y) < hitPx
+                                            }
+                                        if (hit != null) {
+                                            activeHandle = hit.second
+                                            lastPosition = position
+                                            event.changes.forEach { it.consume() }
+                                        }
+                                        // No hit — don't consume; map receives the down event.
                                     }
-                                    HandleType.CORNER_TR -> {
-                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
-                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
+
+                                    // Pointer move — only handle if we grabbed a handle on down.
+                                    change.pressed && activeHandle != null -> {
+                                        val dx = position.x - lastPosition.x
+                                        val dy = position.y - lastPosition.y
+                                        lastPosition = position
+                                        bounds = applyHandleDrag(activeHandle!!, bounds, dx, dy, minSidePx)
+                                        event.changes.forEach { it.consume() }
                                     }
-                                    HandleType.CORNER_BL -> {
-                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
-                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
-                                    }
-                                    HandleType.CORNER_BR -> {
-                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
-                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
-                                    }
-                                    HandleType.EDGE_TOP -> {
-                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
-                                    }
-                                    HandleType.EDGE_BOTTOM -> {
-                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
-                                    }
-                                    HandleType.EDGE_LEFT -> {
-                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
-                                    }
-                                    HandleType.EDGE_RIGHT -> {
-                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
+
+                                    // Pointer up — release the active handle.
+                                    !change.pressed && change.previousPressed -> {
+                                        if (activeHandle != null) {
+                                            event.changes.forEach { it.consume() }
+                                            activeHandle = null
+                                        }
+                                        // No active handle — don't consume; map receives the up event.
                                     }
                                 }
                             }
@@ -168,46 +168,48 @@ internal fun MapRegionPickerContent(
             val handleFillColor = Color.White
             val strokeWidth = 2.dp.toPx()
 
+            val b = bounds
+
             // Semi-transparent overlay outside the selection rectangle
             drawRect(
                 color = overlayColor,
                 topLeft = Offset(0f, 0f),
-                size = Size(size.width, boxTop),
+                size = Size(size.width, b.top),
             )
             drawRect(
                 color = overlayColor,
-                topLeft = Offset(0f, boxBottom),
-                size = Size(size.width, size.height - boxBottom),
+                topLeft = Offset(0f, b.bottom),
+                size = Size(size.width, size.height - b.bottom),
             )
             drawRect(
                 color = overlayColor,
-                topLeft = Offset(0f, boxTop),
-                size = Size(boxLeft, boxBottom - boxTop),
+                topLeft = Offset(0f, b.top),
+                size = Size(b.left, b.bottom - b.top),
             )
             drawRect(
                 color = overlayColor,
-                topLeft = Offset(boxRight, boxTop),
-                size = Size(size.width - boxRight, boxBottom - boxTop),
+                topLeft = Offset(b.right, b.top),
+                size = Size(size.width - b.right, b.bottom - b.top),
             )
 
             // Selection rectangle border
             drawRect(
                 color = strokeColor,
-                topLeft = Offset(boxLeft, boxTop),
-                size = Size(boxRight - boxLeft, boxBottom - boxTop),
+                topLeft = Offset(b.left, b.top),
+                size = Size(b.right - b.left, b.bottom - b.top),
                 style = Stroke(width = strokeWidth),
             )
 
-            val midX = (boxLeft + boxRight) / 2f
-            val midY = (boxTop + boxBottom) / 2f
+            val midX = (b.left + b.right) / 2f
+            val midY = (b.top + b.bottom) / 2f
 
             // Corner handles
             val corners =
                 listOf(
-                    Offset(boxLeft, boxTop),
-                    Offset(boxRight, boxTop),
-                    Offset(boxLeft, boxBottom),
-                    Offset(boxRight, boxBottom),
+                    Offset(b.left, b.top),
+                    Offset(b.right, b.top),
+                    Offset(b.left, b.bottom),
+                    Offset(b.right, b.bottom),
                 )
             corners.forEach { center ->
                 drawCircle(color = handleFillColor, radius = handleRadiusPx, center = center)
@@ -222,10 +224,10 @@ internal fun MapRegionPickerContent(
             // Edge midpoint handles
             val edgeMids =
                 listOf(
-                    Offset(midX, boxTop),
-                    Offset(midX, boxBottom),
-                    Offset(boxLeft, midY),
-                    Offset(boxRight, midY),
+                    Offset(midX, b.top),
+                    Offset(midX, b.bottom),
+                    Offset(b.left, midY),
+                    Offset(b.right, midY),
                 )
             edgeMids.forEach { center ->
                 drawCircle(color = handleFillColor, radius = handleRadiusPx, center = center)
@@ -289,3 +291,48 @@ private enum class HandleType {
     EDGE_LEFT,
     EDGE_RIGHT,
 }
+
+private data class BoxBounds(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+)
+
+private fun applyHandleDrag(
+    handle: HandleType,
+    bounds: BoxBounds,
+    dx: Float,
+    dy: Float,
+    minSidePx: Float,
+): BoxBounds =
+    when (handle) {
+        HandleType.CORNER_TL ->
+            bounds.copy(
+                left = (bounds.left + dx).coerceAtMost(bounds.right - minSidePx),
+                top = (bounds.top + dy).coerceAtMost(bounds.bottom - minSidePx),
+            )
+        HandleType.CORNER_TR ->
+            bounds.copy(
+                right = (bounds.right + dx).coerceAtLeast(bounds.left + minSidePx),
+                top = (bounds.top + dy).coerceAtMost(bounds.bottom - minSidePx),
+            )
+        HandleType.CORNER_BL ->
+            bounds.copy(
+                left = (bounds.left + dx).coerceAtMost(bounds.right - minSidePx),
+                bottom = (bounds.bottom + dy).coerceAtLeast(bounds.top + minSidePx),
+            )
+        HandleType.CORNER_BR ->
+            bounds.copy(
+                right = (bounds.right + dx).coerceAtLeast(bounds.left + minSidePx),
+                bottom = (bounds.bottom + dy).coerceAtLeast(bounds.top + minSidePx),
+            )
+        HandleType.EDGE_TOP ->
+            bounds.copy(top = (bounds.top + dy).coerceAtMost(bounds.bottom - minSidePx))
+        HandleType.EDGE_BOTTOM ->
+            bounds.copy(bottom = (bounds.bottom + dy).coerceAtLeast(bounds.top + minSidePx))
+        HandleType.EDGE_LEFT ->
+            bounds.copy(left = (bounds.left + dx).coerceAtMost(bounds.right - minSidePx))
+        HandleType.EDGE_RIGHT ->
+            bounds.copy(right = (bounds.right + dx).coerceAtLeast(bounds.left + minSidePx))
+    }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -65,7 +65,7 @@ fun MapRegionPickerScreen(
 internal fun MapRegionPickerContent(
     onRegionSelected: (BoundingBox) -> Unit,
     onDismiss: () -> Unit,
-    mapLayer: @Composable () -> Unit = {},
+    mapLayer: @Composable () -> Unit,
 ) {
     var bounds by remember { mutableStateOf(BoxBounds(0f, 0f, 0f, 0f)) }
     var initialized by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -400,14 +400,14 @@ private enum class HandleType {
     EDGE_RIGHT,
 }
 
-private data class BoxBounds(
+internal data class BoxBounds(
     val left: Float,
     val top: Float,
     val right: Float,
     val bottom: Float,
 )
 
-private fun isInsideBox(
+internal fun isInsideBox(
     position: Offset,
     bounds: BoxBounds,
 ): Boolean =
@@ -416,7 +416,7 @@ private fun isInsideBox(
         position.y > bounds.top &&
         position.y < bounds.bottom
 
-private fun BoxBounds.translate(
+internal fun BoxBounds.translate(
     dx: Float,
     dy: Float,
     screenWidth: Float,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -1,0 +1,291 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
+import com.jordankurtz.piawaremobile.map.MapViewModel
+import com.jordankurtz.piawaremobile.map.OpenStreetMap
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_cancel
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_confirm
+import kotlin.math.abs
+
+private const val INITIAL_BOX_FRACTION = 0.6f
+private val MIN_SIDE_LENGTH_DP = 80.dp
+private val HANDLE_RADIUS_DP = 12.dp
+private val HANDLE_HIT_TARGET_DP = 24.dp
+
+@Composable
+fun MapRegionPickerScreen(
+    onRegionSelected: (BoundingBox) -> Unit,
+    onDismiss: () -> Unit,
+    mapViewModel: MapViewModel = koinViewModel(),
+) {
+    MapRegionPickerContent(
+        onRegionSelected = onRegionSelected,
+        onDismiss = onDismiss,
+        mapLayer = {
+            OpenStreetMap(
+                state = mapViewModel.state,
+                modifier = Modifier.fillMaxSize(),
+            )
+        },
+    )
+}
+
+@Composable
+internal fun MapRegionPickerContent(
+    onRegionSelected: (BoundingBox) -> Unit,
+    onDismiss: () -> Unit,
+    mapLayer: @Composable () -> Unit = {},
+) {
+    var boxLeft by remember { mutableFloatStateOf(0f) }
+    var boxTop by remember { mutableFloatStateOf(0f) }
+    var boxRight by remember { mutableFloatStateOf(0f) }
+    var boxBottom by remember { mutableFloatStateOf(0f) }
+
+    var initialized by remember { mutableStateOf(false) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        mapLayer()
+
+        Canvas(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .onSizeChanged { size ->
+                        val w = size.toSize().width
+                        val h = size.toSize().height
+                        if (!initialized && w > 0f && h > 0f) {
+                            val margin = (1f - INITIAL_BOX_FRACTION) / 2f
+                            boxLeft = w * margin
+                            boxTop = h * margin
+                            boxRight = w * (1f - margin)
+                            boxBottom = h * (1f - margin)
+                            initialized = true
+                        }
+                    }
+                    .pointerInput(Unit) {
+                        val minSidePx = MIN_SIDE_LENGTH_DP.toPx()
+                        val hitPx = HANDLE_HIT_TARGET_DP.toPx()
+
+                        detectDragGestures { change, dragAmount ->
+                            change.consume()
+                            val x = change.position.x - dragAmount.x
+                            val y = change.position.y - dragAmount.y
+                            val dx = dragAmount.x
+                            val dy = dragAmount.y
+
+                            val midX = (boxLeft + boxRight) / 2f
+                            val midY = (boxTop + boxBottom) / 2f
+
+                            val handlePositions =
+                                listOf(
+                                    Offset(boxLeft, boxTop) to HandleType.CORNER_TL,
+                                    Offset(boxRight, boxTop) to HandleType.CORNER_TR,
+                                    Offset(boxLeft, boxBottom) to HandleType.CORNER_BL,
+                                    Offset(boxRight, boxBottom) to HandleType.CORNER_BR,
+                                    Offset(midX, boxTop) to HandleType.EDGE_TOP,
+                                    Offset(midX, boxBottom) to HandleType.EDGE_BOTTOM,
+                                    Offset(boxLeft, midY) to HandleType.EDGE_LEFT,
+                                    Offset(boxRight, midY) to HandleType.EDGE_RIGHT,
+                                )
+
+                            val hit =
+                                handlePositions.firstOrNull { (pos, _) ->
+                                    abs(x - pos.x) < hitPx && abs(y - pos.y) < hitPx
+                                }
+
+                            if (hit != null) {
+                                when (hit.second) {
+                                    HandleType.CORNER_TL -> {
+                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
+                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
+                                    }
+                                    HandleType.CORNER_TR -> {
+                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
+                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
+                                    }
+                                    HandleType.CORNER_BL -> {
+                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
+                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
+                                    }
+                                    HandleType.CORNER_BR -> {
+                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
+                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
+                                    }
+                                    HandleType.EDGE_TOP -> {
+                                        boxTop = (boxTop + dy).coerceAtMost(boxBottom - minSidePx)
+                                    }
+                                    HandleType.EDGE_BOTTOM -> {
+                                        boxBottom = (boxBottom + dy).coerceAtLeast(boxTop + minSidePx)
+                                    }
+                                    HandleType.EDGE_LEFT -> {
+                                        boxLeft = (boxLeft + dx).coerceAtMost(boxRight - minSidePx)
+                                    }
+                                    HandleType.EDGE_RIGHT -> {
+                                        boxRight = (boxRight + dx).coerceAtLeast(boxLeft + minSidePx)
+                                    }
+                                }
+                            }
+                        }
+                    },
+        ) {
+            if (!initialized) return@Canvas
+
+            val handleRadiusPx = HANDLE_RADIUS_DP.toPx()
+            val overlayColor = Color.Black.copy(alpha = 0.35f)
+            val strokeColor = Color.White
+            val handleFillColor = Color.White
+            val strokeWidth = 2.dp.toPx()
+
+            // Semi-transparent overlay outside the selection rectangle
+            drawRect(
+                color = overlayColor,
+                topLeft = Offset(0f, 0f),
+                size = Size(size.width, boxTop),
+            )
+            drawRect(
+                color = overlayColor,
+                topLeft = Offset(0f, boxBottom),
+                size = Size(size.width, size.height - boxBottom),
+            )
+            drawRect(
+                color = overlayColor,
+                topLeft = Offset(0f, boxTop),
+                size = Size(boxLeft, boxBottom - boxTop),
+            )
+            drawRect(
+                color = overlayColor,
+                topLeft = Offset(boxRight, boxTop),
+                size = Size(size.width - boxRight, boxBottom - boxTop),
+            )
+
+            // Selection rectangle border
+            drawRect(
+                color = strokeColor,
+                topLeft = Offset(boxLeft, boxTop),
+                size = Size(boxRight - boxLeft, boxBottom - boxTop),
+                style = Stroke(width = strokeWidth),
+            )
+
+            val midX = (boxLeft + boxRight) / 2f
+            val midY = (boxTop + boxBottom) / 2f
+
+            // Corner handles
+            val corners =
+                listOf(
+                    Offset(boxLeft, boxTop),
+                    Offset(boxRight, boxTop),
+                    Offset(boxLeft, boxBottom),
+                    Offset(boxRight, boxBottom),
+                )
+            corners.forEach { center ->
+                drawCircle(color = handleFillColor, radius = handleRadiusPx, center = center)
+                drawCircle(
+                    color = strokeColor,
+                    radius = handleRadiusPx,
+                    center = center,
+                    style = Stroke(width = strokeWidth),
+                )
+            }
+
+            // Edge midpoint handles
+            val edgeMids =
+                listOf(
+                    Offset(midX, boxTop),
+                    Offset(midX, boxBottom),
+                    Offset(boxLeft, midY),
+                    Offset(boxRight, midY),
+                )
+            edgeMids.forEach { center ->
+                drawCircle(color = handleFillColor, radius = handleRadiusPx, center = center)
+                drawCircle(
+                    color = strokeColor,
+                    radius = handleRadiusPx,
+                    center = center,
+                    style = Stroke(width = strokeWidth),
+                )
+            }
+        }
+
+        BottomAppBar(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding(),
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(Res.string.offline_maps_picker_cancel))
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                Button(
+                    onClick = {
+                        // Coordinate conversion is deferred to the backend phase — return mock bounds
+                        onRegionSelected(
+                            BoundingBox(
+                                minLat = 37.0,
+                                maxLat = 38.0,
+                                minLon = -122.5,
+                                maxLon = -121.5,
+                            ),
+                        )
+                    },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(Res.string.offline_maps_picker_confirm))
+                }
+            }
+        }
+    }
+}
+
+private enum class HandleType {
+    CORNER_TL,
+    CORNER_TR,
+    CORNER_BL,
+    CORNER_BR,
+    EDGE_TOP,
+    EDGE_BOTTOM,
+    EDGE_LEFT,
+    EDGE_RIGHT,
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -2,6 +2,7 @@ package com.jordankurtz.piawaremobile.map.offline
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,23 +29,36 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.jordankurtz.piawaremobile.map.MapViewModel
 import com.jordankurtz.piawaremobile.map.OpenStreetMap
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.ic_edit
+import piawaremobile.composeapp.generated.resources.ic_map
 import piawaremobile.composeapp.generated.resources.offline_maps_picker_cancel
 import piawaremobile.composeapp.generated.resources.offline_maps_picker_confirm
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_mode_box
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_mode_map
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_switch_to_box_mode
+import piawaremobile.composeapp.generated.resources.offline_maps_picker_switch_to_map_mode
 import kotlin.math.abs
 
 private const val INITIAL_BOX_FRACTION = 0.6f
 private val MIN_SIDE_LENGTH_DP = 80.dp
 private val HANDLE_RADIUS_DP = 12.dp
 private val HANDLE_HIT_TARGET_DP = 24.dp
+
+private enum class InteractionMode {
+    MAP,
+    BOX,
+}
 
 @Composable
 fun MapRegionPickerScreen(
@@ -69,9 +86,27 @@ internal fun MapRegionPickerContent(
 ) {
     var bounds by remember { mutableStateOf(BoxBounds(0f, 0f, 0f, 0f)) }
     var initialized by remember { mutableStateOf(false) }
+    var interactionMode by remember { mutableStateOf(InteractionMode.BOX) }
+    var screenWidth by remember { mutableStateOf(0f) }
+    var screenHeight by remember { mutableStateOf(0f) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         mapLayer()
+
+        // The pointerInput modifier is only applied in BOX mode. In MAP mode the Canvas carries no
+        // pointer handling at all, so all touch events fall through to the underlying map.
+        val boxModePointerInput =
+            if (interactionMode == InteractionMode.BOX) {
+                Modifier.pointerInput(interactionMode) {
+                    handleBoxGestures(
+                        getBounds = { bounds },
+                        setBounds = { bounds = it },
+                        getScreenSize = { screenWidth to screenHeight },
+                    )
+                }
+            } else {
+                Modifier
+            }
 
         Canvas(
             modifier =
@@ -80,6 +115,8 @@ internal fun MapRegionPickerContent(
                     .onSizeChanged { size ->
                         val w = size.toSize().width
                         val h = size.toSize().height
+                        screenWidth = w
+                        screenHeight = h
                         if (!initialized && w > 0f && h > 0f) {
                             val margin = (1f - INITIAL_BOX_FRACTION) / 2f
                             bounds =
@@ -92,73 +129,7 @@ internal fun MapRegionPickerContent(
                             initialized = true
                         }
                     }
-                    .pointerInput(Unit) {
-                        val minSidePx = MIN_SIDE_LENGTH_DP.toPx()
-                        val hitPx = HANDLE_HIT_TARGET_DP.toPx()
-
-                        // Track which handle is being dragged and the last pointer position so we
-                        // can compute deltas across move events.
-                        var activeHandle: HandleType? = null
-                        var lastPosition: Offset = Offset.Zero
-
-                        awaitPointerEventScope {
-                            while (true) {
-                                val event = awaitPointerEvent(PointerEventPass.Initial)
-                                val change = event.changes.firstOrNull() ?: continue
-                                val position = change.position
-
-                                val midX = (bounds.left + bounds.right) / 2f
-                                val midY = (bounds.top + bounds.bottom) / 2f
-
-                                val handlePositions =
-                                    listOf(
-                                        Offset(bounds.left, bounds.top) to HandleType.CORNER_TL,
-                                        Offset(bounds.right, bounds.top) to HandleType.CORNER_TR,
-                                        Offset(bounds.left, bounds.bottom) to HandleType.CORNER_BL,
-                                        Offset(bounds.right, bounds.bottom) to HandleType.CORNER_BR,
-                                        Offset(midX, bounds.top) to HandleType.EDGE_TOP,
-                                        Offset(midX, bounds.bottom) to HandleType.EDGE_BOTTOM,
-                                        Offset(bounds.left, midY) to HandleType.EDGE_LEFT,
-                                        Offset(bounds.right, midY) to HandleType.EDGE_RIGHT,
-                                    )
-
-                                when {
-                                    // Pointer down — check if it lands on a handle.
-                                    change.pressed && !change.previousPressed -> {
-                                        val hit =
-                                            handlePositions.firstOrNull { (pos, _) ->
-                                                abs(position.x - pos.x) < hitPx &&
-                                                    abs(position.y - pos.y) < hitPx
-                                            }
-                                        if (hit != null) {
-                                            activeHandle = hit.second
-                                            lastPosition = position
-                                            event.changes.forEach { it.consume() }
-                                        }
-                                        // No hit — don't consume; map receives the down event.
-                                    }
-
-                                    // Pointer move — only handle if we grabbed a handle on down.
-                                    change.pressed && activeHandle != null -> {
-                                        val dx = position.x - lastPosition.x
-                                        val dy = position.y - lastPosition.y
-                                        lastPosition = position
-                                        bounds = applyHandleDrag(activeHandle!!, bounds, dx, dy, minSidePx)
-                                        event.changes.forEach { it.consume() }
-                                    }
-
-                                    // Pointer up — release the active handle.
-                                    !change.pressed && change.previousPressed -> {
-                                        if (activeHandle != null) {
-                                            event.changes.forEach { it.consume() }
-                                            activeHandle = null
-                                        }
-                                        // No active handle — don't consume; map receives the up event.
-                                    }
-                                }
-                            }
-                        }
-                    },
+                    .then(boxModePointerInput),
         ) {
             if (!initialized) return@Canvas
 
@@ -240,6 +211,51 @@ internal fun MapRegionPickerContent(
             }
         }
 
+        // Mode toggle FAB — top-end corner
+        Column(
+            modifier =
+                Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp),
+            horizontalAlignment = Alignment.End,
+        ) {
+            Text(
+                text =
+                    stringResource(
+                        if (interactionMode == InteractionMode.MAP) {
+                            Res.string.offline_maps_picker_mode_map
+                        } else {
+                            Res.string.offline_maps_picker_mode_box
+                        },
+                    ),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+            FloatingActionButton(
+                onClick = {
+                    interactionMode =
+                        if (interactionMode == InteractionMode.MAP) {
+                            InteractionMode.BOX
+                        } else {
+                            InteractionMode.MAP
+                        }
+                },
+            ) {
+                if (interactionMode == InteractionMode.MAP) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_edit),
+                        contentDescription = stringResource(Res.string.offline_maps_picker_switch_to_box_mode),
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_map),
+                        contentDescription = stringResource(Res.string.offline_maps_picker_switch_to_map_mode),
+                    )
+                }
+            }
+        }
+
         BottomAppBar(
             modifier =
                 Modifier
@@ -281,6 +297,98 @@ internal fun MapRegionPickerContent(
     }
 }
 
+/**
+ * Drives the pointer gesture loop for box-editing mode.
+ *
+ * Handles are checked first; if the down event lands inside the box (but not on a handle), the
+ * entire box is translated on subsequent drag events. Events that miss both handles and the box
+ * interior are not consumed, preserving fall-through for the underlying map.
+ */
+private suspend fun PointerInputScope.handleBoxGestures(
+    getBounds: () -> BoxBounds,
+    setBounds: (BoxBounds) -> Unit,
+    getScreenSize: () -> Pair<Float, Float>,
+) {
+    val minSidePx = MIN_SIDE_LENGTH_DP.toPx()
+    val hitPx = HANDLE_HIT_TARGET_DP.toPx()
+
+    var activeHandle: HandleType? = null
+    var isMovingBox = false
+    var lastPosition: Offset = Offset.Zero
+
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val change = event.changes.firstOrNull() ?: continue
+            val position = change.position
+            val bounds = getBounds()
+
+            val midX = (bounds.left + bounds.right) / 2f
+            val midY = (bounds.top + bounds.bottom) / 2f
+
+            val handlePositions =
+                listOf(
+                    Offset(bounds.left, bounds.top) to HandleType.CORNER_TL,
+                    Offset(bounds.right, bounds.top) to HandleType.CORNER_TR,
+                    Offset(bounds.left, bounds.bottom) to HandleType.CORNER_BL,
+                    Offset(bounds.right, bounds.bottom) to HandleType.CORNER_BR,
+                    Offset(midX, bounds.top) to HandleType.EDGE_TOP,
+                    Offset(midX, bounds.bottom) to HandleType.EDGE_BOTTOM,
+                    Offset(bounds.left, midY) to HandleType.EDGE_LEFT,
+                    Offset(bounds.right, midY) to HandleType.EDGE_RIGHT,
+                )
+
+            when {
+                // Pointer down — check handle hit, then box interior, then ignore.
+                change.pressed && !change.previousPressed -> {
+                    val hit =
+                        handlePositions.firstOrNull { (pos, _) ->
+                            abs(position.x - pos.x) < hitPx && abs(position.y - pos.y) < hitPx
+                        }
+                    when {
+                        hit != null -> {
+                            activeHandle = hit.second
+                            lastPosition = position
+                            event.changes.forEach { it.consume() }
+                        }
+                        isInsideBox(position, bounds) -> {
+                            isMovingBox = true
+                            lastPosition = position
+                            event.changes.forEach { it.consume() }
+                        }
+                        // Outside box and not on a handle — don't consume.
+                    }
+                }
+
+                // Pointer move — apply handle drag or box translate.
+                change.pressed && (activeHandle != null || isMovingBox) -> {
+                    val dx = position.x - lastPosition.x
+                    val dy = position.y - lastPosition.y
+                    lastPosition = position
+                    val (sw, sh) = getScreenSize()
+                    setBounds(
+                        if (activeHandle != null) {
+                            applyHandleDrag(activeHandle!!, bounds, dx, dy, minSidePx)
+                        } else {
+                            bounds.translate(dx, dy, sw, sh)
+                        },
+                    )
+                    event.changes.forEach { it.consume() }
+                }
+
+                // Pointer up — release active gesture.
+                !change.pressed && change.previousPressed -> {
+                    if (activeHandle != null || isMovingBox) {
+                        event.changes.forEach { it.consume() }
+                        activeHandle = null
+                        isMovingBox = false
+                    }
+                }
+            }
+        }
+    }
+}
+
 private enum class HandleType {
     CORNER_TL,
     CORNER_TR,
@@ -298,6 +406,33 @@ private data class BoxBounds(
     val right: Float,
     val bottom: Float,
 )
+
+private fun isInsideBox(
+    position: Offset,
+    bounds: BoxBounds,
+): Boolean =
+    position.x > bounds.left &&
+        position.x < bounds.right &&
+        position.y > bounds.top &&
+        position.y < bounds.bottom
+
+private fun BoxBounds.translate(
+    dx: Float,
+    dy: Float,
+    screenWidth: Float,
+    screenHeight: Float,
+): BoxBounds {
+    val boxWidth = right - left
+    val boxHeight = bottom - top
+    val newLeft = (left + dx).coerceIn(0f, screenWidth - boxWidth)
+    val newTop = (top + dy).coerceIn(0f, screenHeight - boxHeight)
+    return BoxBounds(
+        left = newLeft,
+        top = newTop,
+        right = newLeft + boxWidth,
+        bottom = newTop + boxHeight,
+    )
+}
 
 private fun applyHandleDrag(
     handle: HandleType,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
@@ -1,4 +1,4 @@
-package com.jordankurtz.piawaremobile.settings.ui
+package com.jordankurtz.piawaremobile.map.offline
 
 data class OfflineRegion(
     val id: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsScreens.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsScreens.kt
@@ -4,4 +4,6 @@ sealed class SettingsScreens {
     object Main : SettingsScreens()
 
     object Servers : SettingsScreens()
+
+    object OfflineMaps : SettingsScreens()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
@@ -25,25 +25,42 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.jordankurtz.piawaremobile.map.offline.BoundingBox
 import org.jetbrains.compose.resources.stringResource
 import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_bounds_label
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_cancel
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_download
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_estimate
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_max_zoom
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_min_zoom
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_name_label
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_select_on_map
 import piawaremobile.composeapp.generated.resources.offline_maps_dialog_title
+import kotlin.math.abs
+import kotlin.math.round
 
 private const val DEFAULT_MIN_ZOOM = 8f
 private const val DEFAULT_MAX_ZOOM = 14f
 private const val MIN_ZOOM_LIMIT = 1f
 private const val MAX_ZOOM_LIMIT = 18f
+private const val COORD_DECIMAL_PLACES = 4
+private const val COORD_SCALE = 10_000.0
+
+private fun formatCoord(value: Double): String {
+    val rounded = round(abs(value) * COORD_SCALE) / COORD_SCALE
+    val sign = if (value < 0.0) "-" else ""
+    val intPart = rounded.toLong()
+    val fracPart = round((rounded - intPart) * COORD_SCALE).toLong()
+    return "$sign$intPart.${fracPart.toString().padStart(COORD_DECIMAL_PLACES, '0')}"
+}
 
 @Composable
 fun DownloadRegionDialog(
     onDismiss: () -> Unit,
     onConfirm: (name: String, minZoom: Int, maxZoom: Int) -> Unit,
+    selectedBounds: BoundingBox? = null,
+    onSelectOnMap: () -> Unit = {},
 ) {
     var name by remember { mutableStateOf("") }
     var minZoom by remember { mutableFloatStateOf(DEFAULT_MIN_ZOOM) }
@@ -78,6 +95,31 @@ fun DownloadRegionDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextButton(
+                    onClick = onSelectOnMap,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(Res.string.offline_maps_dialog_select_on_map))
+                }
+
+                if (selectedBounds != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text =
+                            stringResource(
+                                Res.string.offline_maps_dialog_bounds_label,
+                                formatCoord(selectedBounds.minLat),
+                                formatCoord(selectedBounds.minLon),
+                                formatCoord(selectedBounds.maxLat),
+                                formatCoord(selectedBounds.maxLon),
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(16.dp))
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
@@ -48,10 +48,11 @@ private const val COORD_DECIMAL_PLACES = 4
 private const val COORD_SCALE = 10_000.0
 
 private fun formatCoord(value: Double): String {
-    val rounded = round(abs(value) * COORD_SCALE) / COORD_SCALE
-    val sign = if (value < 0.0) "-" else ""
-    val intPart = rounded.toLong()
-    val fracPart = round((rounded - intPart) * COORD_SCALE).toLong()
+    val rounded = round(value * COORD_SCALE) / COORD_SCALE
+    val sign = if (rounded < 0.0) "-" else ""
+    val abs = abs(rounded)
+    val intPart = abs.toLong()
+    val fracPart = round((abs - intPart) * COORD_SCALE).toLong()
     return "$sign$intPart.${fracPart.toString().padStart(COORD_DECIMAL_PLACES, '0')}"
 }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
@@ -1,0 +1,148 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import org.jetbrains.compose.resources.stringResource
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_cancel
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_download
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_estimate
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_max_zoom
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_min_zoom
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_name_label
+import piawaremobile.composeapp.generated.resources.offline_maps_dialog_title
+
+private const val DEFAULT_MIN_ZOOM = 8f
+private const val DEFAULT_MAX_ZOOM = 14f
+private const val MIN_ZOOM_LIMIT = 1f
+private const val MAX_ZOOM_LIMIT = 18f
+
+@Composable
+fun DownloadRegionDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, minZoom: Int, maxZoom: Int) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var minZoom by remember { mutableFloatStateOf(DEFAULT_MIN_ZOOM) }
+    var maxZoom by remember { mutableFloatStateOf(DEFAULT_MAX_ZOOM) }
+
+    val isValid = name.isNotBlank()
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(8.dp),
+            color = MaterialTheme.colorScheme.surface,
+            shadowElevation = 8.dp,
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .padding(24.dp)
+                        .width(IntrinsicSize.Min),
+            ) {
+                Text(
+                    text = stringResource(Res.string.offline_maps_dialog_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(Res.string.offline_maps_dialog_name_label)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(Res.string.offline_maps_dialog_min_zoom, minZoom.toInt()),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Slider(
+                    value = minZoom,
+                    onValueChange = {
+                        minZoom = it
+                        if (maxZoom < it) {
+                            maxZoom = it
+                        }
+                    },
+                    valueRange = MIN_ZOOM_LIMIT..MAX_ZOOM_LIMIT,
+                    steps = (MAX_ZOOM_LIMIT - MIN_ZOOM_LIMIT).toInt() - 1,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(Res.string.offline_maps_dialog_max_zoom, maxZoom.toInt()),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Slider(
+                    value = maxZoom,
+                    onValueChange = {
+                        maxZoom = it
+                        if (minZoom > it) {
+                            minZoom = it
+                        }
+                    },
+                    valueRange = MIN_ZOOM_LIMIT..MAX_ZOOM_LIMIT,
+                    steps = (MAX_ZOOM_LIMIT - MIN_ZOOM_LIMIT).toInt() - 1,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(Res.string.offline_maps_dialog_estimate),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(Res.string.offline_maps_dialog_cancel))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TextButton(
+                        onClick = { onConfirm(name.trim(), minZoom.toInt(), maxZoom.toInt()) },
+                        enabled = isValid,
+                    ) {
+                        Text(stringResource(Res.string.offline_maps_dialog_download))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
@@ -48,6 +48,7 @@ import piawaremobile.composeapp.generated.resources.enable_flightaware_api_descr
 import piawaremobile.composeapp.generated.resources.enable_flightaware_api_title
 import piawaremobile.composeapp.generated.resources.flightaware_api_key_title
 import piawaremobile.composeapp.generated.resources.ic_chevron_right
+import piawaremobile.composeapp.generated.resources.offline_maps_settings_title
 import piawaremobile.composeapp.generated.resources.open_urls_externally_description
 import piawaremobile.composeapp.generated.resources.open_urls_externally_title
 import piawaremobile.composeapp.generated.resources.preferences_title
@@ -69,6 +70,7 @@ import piawaremobile.composeapp.generated.resources.trail_display_mode_title
 @Composable
 fun MainScreen(
     onServersClicked: () -> Unit,
+    onOfflineMapsClicked: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val settingsState by viewModel.settings.collectAsState()
@@ -98,6 +100,20 @@ fun MainScreen(
                 SettingsItem(
                     title = stringResource(Res.string.servers_title),
                     onClick = onServersClicked,
+                    trailingIcon = {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_chevron_right),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    },
+                )
+            }
+
+            item {
+                SettingsItem(
+                    title = stringResource(Res.string.offline_maps_settings_title),
+                    onClick = onOfflineMapsClicked,
                     trailingIcon = {
                         Icon(
                             painter = painterResource(Res.drawable.ic_chevron_right),

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import piawaremobile.composeapp.generated.resources.Res

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -1,0 +1,194 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.ic_add
+import piawaremobile.composeapp.generated.resources.ic_arrow_back
+import piawaremobile.composeapp.generated.resources.ic_delete
+import piawaremobile.composeapp.generated.resources.navigate_back
+import piawaremobile.composeapp.generated.resources.offline_maps_add_region
+import piawaremobile.composeapp.generated.resources.offline_maps_empty_message
+import piawaremobile.composeapp.generated.resources.offline_maps_empty_title
+import piawaremobile.composeapp.generated.resources.offline_maps_region_delete
+import piawaremobile.composeapp.generated.resources.offline_maps_region_size
+import piawaremobile.composeapp.generated.resources.offline_maps_region_zoom
+import piawaremobile.composeapp.generated.resources.offline_maps_title
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OfflineMapsScreen(
+    onBack: () -> Unit,
+    regions: List<OfflineRegion> = emptyList(),
+    onDeleteRegion: (OfflineRegion) -> Unit = {},
+) {
+    var showDownloadDialog by remember { mutableStateOf(false) }
+
+    if (showDownloadDialog) {
+        DownloadRegionDialog(
+            onDismiss = { showDownloadDialog = false },
+            onConfirm = { _, _, _ -> showDownloadDialog = false },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.offline_maps_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_arrow_back),
+                            contentDescription = stringResource(Res.string.navigate_back),
+                        )
+                    }
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                actions = {
+                    IconButton(
+                        onClick = { showDownloadDialog = true },
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_add),
+                            contentDescription = stringResource(Res.string.offline_maps_add_region),
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (regions.isEmpty()) {
+                OfflineMapsEmptyState()
+            } else {
+                OfflineRegionList(
+                    regions = regions,
+                    onDeleteRegion = onDeleteRegion,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OfflineMapsEmptyState() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(Res.string.offline_maps_empty_title),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(Res.string.offline_maps_empty_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun OfflineRegionList(
+    regions: List<OfflineRegion>,
+    onDeleteRegion: (OfflineRegion) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        items(regions, key = { it.id }) { region ->
+            OfflineRegionItem(
+                region = region,
+                onDelete = { onDeleteRegion(region) },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun OfflineRegionItem(
+    region: OfflineRegion,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = region.name,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = stringResource(Res.string.offline_maps_region_zoom, region.minZoom, region.maxZoom),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.offline_maps_region_size, region.storageSizeMb),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = region.downloadDate,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                painter = painterResource(Res.drawable.ic_delete),
+                contentDescription = stringResource(Res.string.offline_maps_region_delete),
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.jordankurtz.piawaremobile.map.offline.BoundingBox
+import com.jordankurtz.piawaremobile.map.offline.MapRegionPickerScreen
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -50,11 +52,39 @@ fun OfflineMapsScreen(
     onDeleteRegion: (OfflineRegion) -> Unit = {},
 ) {
     var showDownloadDialog by remember { mutableStateOf(false) }
+    var showMapPicker by remember { mutableStateOf(false) }
+    var pendingBounds by remember { mutableStateOf<BoundingBox?>(null) }
+
+    if (showMapPicker) {
+        MapRegionPickerScreen(
+            onRegionSelected = { bounds ->
+                pendingBounds = bounds
+                showMapPicker = false
+                showDownloadDialog = true
+            },
+            onDismiss = {
+                showMapPicker = false
+                showDownloadDialog = true
+            },
+        )
+        return
+    }
 
     if (showDownloadDialog) {
         DownloadRegionDialog(
-            onDismiss = { showDownloadDialog = false },
-            onConfirm = { _, _, _ -> showDownloadDialog = false },
+            onDismiss = {
+                showDownloadDialog = false
+                pendingBounds = null
+            },
+            onConfirm = { _, _, _ ->
+                showDownloadDialog = false
+                pendingBounds = null
+            },
+            selectedBounds = pendingBounds,
+            onSelectOnMap = {
+                showDownloadDialog = false
+                showMapPicker = true
+            },
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegion.kt
@@ -1,0 +1,10 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+data class OfflineRegion(
+    val id: String,
+    val name: String,
+    val minZoom: Int,
+    val maxZoom: Int,
+    val storageSizeMb: Int,
+    val downloadDate: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
@@ -24,8 +24,15 @@ fun SettingsScreen() {
         ) { screen ->
             when (screen) {
                 SettingsScreens.Main ->
-                    MainScreen(onServersClicked = { currentScreen = SettingsScreens.Servers })
+                    MainScreen(
+                        onServersClicked = { currentScreen = SettingsScreens.Servers },
+                        onOfflineMapsClicked = { currentScreen = SettingsScreens.OfflineMaps },
+                    )
                 SettingsScreens.Servers -> ServersScreen(onBack = {})
+                SettingsScreens.OfflineMaps ->
+                    OfflineMapsScreen(
+                        onBack = { currentScreen = SettingsScreens.Main },
+                    )
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/BoxBoundsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/BoxBoundsTest.kt
@@ -1,0 +1,129 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BoxBoundsTest {
+    // A 200×100 box positioned at (100, 50) in a 500×400 screen
+    private val bounds = BoxBounds(left = 100f, top = 50f, right = 300f, bottom = 150f)
+    private val screenWidth = 500f
+    private val screenHeight = 400f
+
+    // --- BoxBounds.translate ---
+
+    @Test
+    fun translateNormalDeltaWithinBounds() {
+        val result = bounds.translate(dx = 10f, dy = 20f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(110f, result.left, 0.001f)
+        assertEquals(70f, result.top, 0.001f)
+        assertEquals(310f, result.right, 0.001f)
+        assertEquals(170f, result.bottom, 0.001f)
+    }
+
+    @Test
+    fun translateClampsAtLeftEdge() {
+        // dx = -200 would push left to -100, should clamp left to 0
+        val result = bounds.translate(dx = -200f, dy = 0f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(0f, result.left, 0.001f)
+    }
+
+    @Test
+    fun translateClampsAtRightEdge() {
+        // dx = 300 would push right to 600, past screenWidth=500; right should be clamped to 500
+        val result = bounds.translate(dx = 300f, dy = 0f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(screenWidth, result.right, 0.001f)
+    }
+
+    @Test
+    fun translateClampsAtTopEdge() {
+        // dy = -200 would push top to -150, should clamp top to 0
+        val result = bounds.translate(dx = 0f, dy = -200f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(0f, result.top, 0.001f)
+    }
+
+    @Test
+    fun translateClampsAtBottomEdge() {
+        // dy = 400 would push bottom to 550, past screenHeight=400; bottom should be clamped to 400
+        val result = bounds.translate(dx = 0f, dy = 400f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(screenHeight, result.bottom, 0.001f)
+    }
+
+    @Test
+    fun translatePreservesBoxWidthAfterLeftClamp() {
+        val boxWidth = bounds.right - bounds.left
+        val result = bounds.translate(dx = -200f, dy = 0f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(boxWidth, result.right - result.left, 0.001f)
+    }
+
+    @Test
+    fun translatePreservesBoxWidthAfterRightClamp() {
+        val boxWidth = bounds.right - bounds.left
+        val result = bounds.translate(dx = 300f, dy = 0f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(boxWidth, result.right - result.left, 0.001f)
+    }
+
+    @Test
+    fun translatePreservesBoxHeightAfterTopClamp() {
+        val boxHeight = bounds.bottom - bounds.top
+        val result = bounds.translate(dx = 0f, dy = -200f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(boxHeight, result.bottom - result.top, 0.001f)
+    }
+
+    @Test
+    fun translatePreservesBoxHeightAfterBottomClamp() {
+        val boxHeight = bounds.bottom - bounds.top
+        val result = bounds.translate(dx = 0f, dy = 400f, screenWidth = screenWidth, screenHeight = screenHeight)
+        assertEquals(boxHeight, result.bottom - result.top, 0.001f)
+    }
+
+    // --- isInsideBox ---
+
+    @Test
+    fun isInsideBoxReturnsTrueForPointInsideBox() {
+        assertTrue(isInsideBox(Offset(200f, 100f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointLeftOfBox() {
+        assertFalse(isInsideBox(Offset(50f, 100f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointRightOfBox() {
+        assertFalse(isInsideBox(Offset(350f, 100f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointAboveBox() {
+        assertFalse(isInsideBox(Offset(200f, 20f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointBelowBox() {
+        assertFalse(isInsideBox(Offset(200f, 200f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointOnLeftEdge() {
+        // Boundary uses strict inequality (>), so the edge itself is not inside
+        assertFalse(isInsideBox(Offset(100f, 100f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointOnRightEdge() {
+        assertFalse(isInsideBox(Offset(300f, 100f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointOnTopEdge() {
+        assertFalse(isInsideBox(Offset(200f, 50f), bounds))
+    }
+
+    @Test
+    fun isInsideBoxReturnsFalseForPointOnBottomEdge() {
+        assertFalse(isInsideBox(Offset(200f, 150f), bounds))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -17,6 +18,7 @@ class MapRegionPickerScreenTest {
                 MapRegionPickerContent(
                     onRegionSelected = {},
                     onDismiss = {},
+                    mapLayer = {},
                 )
             }
             onNodeWithText("Confirm").assertIsDisplayed()
@@ -31,9 +33,25 @@ class MapRegionPickerScreenTest {
                 MapRegionPickerContent(
                     onRegionSelected = {},
                     onDismiss = { dismissed = true },
+                    mapLayer = {},
                 )
             }
             onNodeWithText("Cancel").performClick()
             assertTrue(dismissed)
+        }
+
+    @Test
+    fun confirmTriggersOnRegionSelectedCallback() =
+        runComposeUiTest {
+            var selectedBounds: BoundingBox? = null
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = { selectedBounds = it },
+                    onDismiss = {},
+                    mapLayer = {},
+                )
+            }
+            onNodeWithText("Confirm").performClick()
+            assertNotNull(selectedBounds)
         }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -1,0 +1,39 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class MapRegionPickerScreenTest {
+    @Test
+    fun confirmAndCancelButtonsRender() =
+        runComposeUiTest {
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = {},
+                    onDismiss = {},
+                )
+            }
+            onNodeWithText("Confirm").assertIsDisplayed()
+            onNodeWithText("Cancel").assertIsDisplayed()
+        }
+
+    @Test
+    fun cancelTriggersDismissCallback() =
+        runComposeUiTest {
+            var dismissed = false
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = {},
+                    onDismiss = { dismissed = true },
+                )
+            }
+            onNodeWithText("Cancel").performClick()
+            assertTrue(dismissed)
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -2,6 +2,7 @@ package com.jordankurtz.piawaremobile.map.offline
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -53,5 +54,53 @@ class MapRegionPickerScreenTest {
             }
             onNodeWithText("Confirm").performClick()
             assertNotNull(selectedBounds)
+        }
+
+    @Test
+    fun modeToggleButtonRendersInBoxModeByDefault() =
+        runComposeUiTest {
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = {},
+                    onDismiss = {},
+                    mapLayer = {},
+                )
+            }
+            // Default mode is BOX — button should offer switching to map mode
+            onNodeWithContentDescription("Switch to map mode").assertIsDisplayed()
+            onNodeWithText("Editing region").assertIsDisplayed()
+        }
+
+    @Test
+    fun modeToggleButtonSwitchesToMapMode() =
+        runComposeUiTest {
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = {},
+                    onDismiss = {},
+                    mapLayer = {},
+                )
+            }
+            // Click toggle: BOX -> MAP
+            onNodeWithContentDescription("Switch to map mode").performClick()
+            onNodeWithContentDescription("Switch to box mode").assertIsDisplayed()
+            onNodeWithText("Moving map").assertIsDisplayed()
+        }
+
+    @Test
+    fun modeToggleButtonRoundTrips() =
+        runComposeUiTest {
+            setContent {
+                MapRegionPickerContent(
+                    onRegionSelected = {},
+                    onDismiss = {},
+                    mapLayer = {},
+                )
+            }
+            // BOX -> MAP -> BOX
+            onNodeWithContentDescription("Switch to map mode").performClick()
+            onNodeWithContentDescription("Switch to box mode").performClick()
+            onNodeWithContentDescription("Switch to map mode").assertIsDisplayed()
+            onNodeWithText("Editing region").assertIsDisplayed()
         }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -1,0 +1,78 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DownloadRegionDialogTest {
+    @Test
+    fun displaysDialogElements() =
+        runComposeUiTest {
+            setContent {
+                DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+            }
+            onNodeWithText("Download Region").assertIsDisplayed()
+            onNodeWithText("Region name").assertIsDisplayed()
+            onNodeWithText("Min zoom: 8").assertIsDisplayed()
+            onNodeWithText("Max zoom: 14").assertIsDisplayed()
+            onNodeWithText("Estimated size depends on zoom levels and area").assertIsDisplayed()
+            onNodeWithText("Cancel").assertIsDisplayed()
+            onNodeWithText("Download").assertIsDisplayed()
+        }
+
+    @Test
+    fun downloadButtonDisabledWhenNameBlank() =
+        runComposeUiTest {
+            setContent {
+                DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+            }
+            onNodeWithText("Download").assertIsNotEnabled()
+        }
+
+    @Test
+    fun downloadButtonEnabledWhenNameNonBlank() =
+        runComposeUiTest {
+            setContent {
+                DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+            }
+            onNodeWithText("Region name").performClick()
+            onNodeWithText("Region name").performTextInput("My Region")
+            onNodeWithText("Download").assertIsEnabled()
+        }
+
+    @Test
+    fun cancelButtonFiresDismissCallback() =
+        runComposeUiTest {
+            var dismissed = false
+            setContent {
+                DownloadRegionDialog(onDismiss = { dismissed = true }, onConfirm = { _, _, _ -> })
+            }
+            onNodeWithText("Cancel").performClick()
+            assertTrue(dismissed)
+        }
+
+    @Test
+    fun confirmWithNameCallsOnConfirmWithCorrectName() =
+        runComposeUiTest {
+            var confirmedName: String? = null
+            setContent {
+                DownloadRegionDialog(
+                    onDismiss = {},
+                    onConfirm = { name, _, _ -> confirmedName = name },
+                )
+            }
+            onNodeWithText("Region name").performClick()
+            onNodeWithText("Region name").performTextInput("Airport Area")
+            onNodeWithText("Download").performClick()
+            assertEquals("Airport Area", confirmedName)
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -114,4 +114,17 @@ class DownloadRegionDialogTest {
             }
             onNodeWithText("Selected bounds: 37.0000, -122.5000 – 38.0000, -121.5000").assertIsDisplayed()
         }
+
+    @Test
+    fun boundsTextNotShownWhenSelectedBoundsNull() =
+        runComposeUiTest {
+            setContent {
+                DownloadRegionDialog(
+                    onDismiss = {},
+                    onConfirm = { _, _, _ -> },
+                    selectedBounds = null,
+                )
+            }
+            onNodeWithText("Selected bounds", substring = true).assertDoesNotExist()
+        }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
+import com.jordankurtz.piawaremobile.map.offline.BoundingBox
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -74,5 +75,43 @@ class DownloadRegionDialogTest {
             onNodeWithText("Region name").performTextInput("Airport Area")
             onNodeWithText("Download").performClick()
             assertEquals("Airport Area", confirmedName)
+        }
+
+    @Test
+    fun selectOnMapButtonIsVisible() =
+        runComposeUiTest {
+            setContent {
+                DownloadRegionDialog(onDismiss = {}, onConfirm = { _, _, _ -> })
+            }
+            onNodeWithText("Select on map").assertIsDisplayed()
+        }
+
+    @Test
+    fun selectOnMapButtonFiresCallback() =
+        runComposeUiTest {
+            var selectOnMapCalled = false
+            setContent {
+                DownloadRegionDialog(
+                    onDismiss = {},
+                    onConfirm = { _, _, _ -> },
+                    onSelectOnMap = { selectOnMapCalled = true },
+                )
+            }
+            onNodeWithText("Select on map").performClick()
+            assertTrue(selectOnMapCalled)
+        }
+
+    @Test
+    fun boundsTextShownWhenSelectedBoundsNonNull() =
+        runComposeUiTest {
+            val bounds = BoundingBox(minLat = 37.0, maxLat = 38.0, minLon = -122.5, maxLon = -121.5)
+            setContent {
+                DownloadRegionDialog(
+                    onDismiss = {},
+                    onConfirm = { _, _, _ -> },
+                    selectedBounds = bounds,
+                )
+            }
+            onNodeWithText("Selected bounds: 37.0000, -122.5000 – 38.0000, -121.5000").assertIsDisplayed()
         }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
@@ -1,0 +1,137 @@
+package com.jordankurtz.piawaremobile.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
+import com.jordankurtz.piawaremobile.settings.ui.OfflineRegion
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class OfflineMapsScreenTest {
+    @Test
+    fun emptyStateShowsNoRegionsMessage() =
+        runComposeUiTest {
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = emptyList(),
+                )
+            }
+            onNodeWithText("No offline regions").assertIsDisplayed()
+            onNodeWithText("Tap + to download a map region for offline use").assertIsDisplayed()
+        }
+
+    @Test
+    fun displaysOfflineMapsTitle() =
+        runComposeUiTest {
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = emptyList(),
+                )
+            }
+            onNodeWithText("Offline Maps").assertIsDisplayed()
+        }
+
+    @Test
+    fun populatedStateShowsRegionNames() =
+        runComposeUiTest {
+            val regions =
+                listOf(
+                    OfflineRegion(
+                        id = "1",
+                        name = "Home Area",
+                        minZoom = 8,
+                        maxZoom = 14,
+                        storageSizeMb = 42,
+                        downloadDate = "2026-03-01",
+                    ),
+                    OfflineRegion(
+                        id = "2",
+                        name = "Airport Region",
+                        minZoom = 10,
+                        maxZoom = 16,
+                        storageSizeMb = 128,
+                        downloadDate = "2026-03-15",
+                    ),
+                )
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = regions,
+                )
+            }
+            onNodeWithText("Home Area").assertIsDisplayed()
+            onNodeWithText("Airport Region").assertIsDisplayed()
+        }
+
+    @Test
+    fun populatedStateShowsStorageSizes() =
+        runComposeUiTest {
+            val regions =
+                listOf(
+                    OfflineRegion(
+                        id = "1",
+                        name = "Home Area",
+                        minZoom = 8,
+                        maxZoom = 14,
+                        storageSizeMb = 42,
+                        downloadDate = "2026-03-01",
+                    ),
+                    OfflineRegion(
+                        id = "2",
+                        name = "Airport Region",
+                        minZoom = 10,
+                        maxZoom = 16,
+                        storageSizeMb = 128,
+                        downloadDate = "2026-03-15",
+                    ),
+                )
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = regions,
+                )
+            }
+            onNodeWithText("42 MB").assertIsDisplayed()
+            onNodeWithText("128 MB").assertIsDisplayed()
+        }
+
+    @Test
+    fun populatedStateShowsZoomRanges() =
+        runComposeUiTest {
+            val regions =
+                listOf(
+                    OfflineRegion(
+                        id = "1",
+                        name = "Home Area",
+                        minZoom = 8,
+                        maxZoom = 14,
+                        storageSizeMb = 42,
+                        downloadDate = "2026-03-01",
+                    ),
+                )
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = regions,
+                )
+            }
+            onNodeWithText("Zoom 8 – 14").assertIsDisplayed()
+        }
+
+    @Test
+    fun addRegionButtonIsDisplayed() =
+        runComposeUiTest {
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = emptyList(),
+                )
+            }
+            onNodeWithContentDescription("Add region").assertIsDisplayed()
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -181,7 +182,7 @@ class OfflineMapsScreenTest {
                 )
             }
             onNodeWithContentDescription("Delete region").performClick()
-            assertTrue(deletedRegion == region)
+            assertEquals(region, deletedRegion)
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
@@ -4,10 +4,12 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
-import com.jordankurtz.piawaremobile.settings.ui.OfflineRegion
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class OfflineMapsScreenTest {
@@ -133,5 +135,66 @@ class OfflineMapsScreenTest {
                 )
             }
             onNodeWithContentDescription("Add region").assertIsDisplayed()
+        }
+
+    @Test
+    fun deleteButtonIsRenderedForRegion() =
+        runComposeUiTest {
+            val regions =
+                listOf(
+                    OfflineRegion(
+                        id = "1",
+                        name = "Home Area",
+                        minZoom = 8,
+                        maxZoom = 14,
+                        storageSizeMb = 42,
+                        downloadDate = "2026-03-01",
+                    ),
+                )
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = regions,
+                )
+            }
+            onNodeWithContentDescription("Delete region").assertIsDisplayed()
+        }
+
+    @Test
+    fun deleteButtonInvokesOnDeleteRegion() =
+        runComposeUiTest {
+            var deletedRegion: OfflineRegion? = null
+            val region =
+                OfflineRegion(
+                    id = "1",
+                    name = "Home Area",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    storageSizeMb = 42,
+                    downloadDate = "2026-03-01",
+                )
+            setContent {
+                OfflineMapsScreen(
+                    onBack = {},
+                    regions = listOf(region),
+                    onDeleteRegion = { deletedRegion = it },
+                )
+            }
+            onNodeWithContentDescription("Delete region").performClick()
+            assertTrue(deletedRegion == region)
+        }
+
+    @Test
+    fun backButtonInvokesOnBack() =
+        runComposeUiTest {
+            var backClicked = false
+            setContent {
+                OfflineMapsScreen(
+                    onBack = { backClicked = true },
+                    regions = emptyList(),
+                )
+            }
+            onNodeWithContentDescription("Back").performClick()
+            assertTrue(backClicked)
         }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
@@ -100,4 +100,28 @@ class SettingsScreenTest {
             onNode(hasScrollAction()).performScrollToNode(hasText("Enable FlightAware API"))
             onNodeWithText("Enable FlightAware API").assertIsDisplayed()
         }
+
+    @Test
+    fun displaysOfflineMapsItem() =
+        runComposeUiTest {
+            setContent {
+                MainScreen(onServersClicked = {}, viewModel = createViewModel())
+            }
+            onNodeWithText("Offline Maps").assertIsDisplayed()
+        }
+
+    @Test
+    fun offlineMapsItemFiresCallback() =
+        runComposeUiTest {
+            var clicked = false
+            setContent {
+                MainScreen(
+                    onServersClicked = {},
+                    onOfflineMapsClicked = { clicked = true },
+                    viewModel = createViewModel(),
+                )
+            }
+            onNodeWithText("Offline Maps").performClick()
+            assertTrue(clicked)
+        }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
@@ -2,8 +2,11 @@ package com.jordankurtz.piawaremobile.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.runComposeUiTest
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.Settings
@@ -94,6 +97,7 @@ class SettingsScreenTest {
             setContent {
                 MainScreen(onServersClicked = {}, viewModel = createViewModel())
             }
+            onNode(hasScrollAction()).performScrollToNode(hasText("Enable FlightAware API"))
             onNodeWithText("Enable FlightAware API").assertIsDisplayed()
         }
 }


### PR DESCRIPTION
## Summary
- Adds offline region list screen in Settings (region name, zoom range, storage size, delete)
- Adds download region dialog (name, zoom sliders, tile count/size estimate)
- Adds `OfflineIndicator` chip on MapScreen (static `visible = false` until backend wired)
- Wires `OfflineMaps` into settings navigation

## Notes
- UI uses static mock data — real data wiring is a follow-up phase
- Offline indicator uses `AnimatedVisibility` and will be shown once the tile pinning layer lands

## Test plan
- [ ] Offline Maps entry visible in Settings
- [ ] Region list shows mock regions with name, zoom range, storage size
- [ ] Empty state shows when no regions (toggle mock data off to verify)
- [ ] "+" button opens download dialog
- [ ] Download dialog has name field, zoom sliders, tile estimate, Download + Cancel
- [ ] Back button returns to Settings main
- [ ] MapScreen unchanged in appearance (indicator hidden)

Part of #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)