### PR TITLE
Fix FlightAware API showing as not configured after opening browser

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModel.kt
@@ -234,7 +234,6 @@ class AircraftViewModel(
     }
 
     private fun openFlightPageInternal(flight: String) {
-        _flightDetails.value = Async.Error("FlightAware API is not configured. Opening on flightaware.com instead.")
         viewModelScope.launch(mainDispatcher) {
             val dateString = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
             val url = "https://www.flightaware.com/live/flight/$flight/history/${

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
@@ -389,7 +389,7 @@ class AircraftViewModelTest {
         }
 
     @Test
-    fun `openFlightPage sets error message before opening URL`() =
+    fun `openFlightPage does not change flightDetails state`() =
         runTest {
             val aircraftList =
                 listOf(
@@ -404,11 +404,10 @@ class AircraftViewModelTest {
             pollTicker.emit(Unit)
             testDispatcher.scheduler.advanceUntilIdle()
 
+            val stateBefore = viewModel.flightDetails.value
             viewModel.openFlightPage("ABC123")
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val details = viewModel.flightDetails.value
-            assertIs<Async.Error>(details)
-            assertTrue(details.message.contains("not configured"))
+            assertEquals(stateBefore, viewModel.flightDetails.value)
         }
 }


### PR DESCRIPTION
## Summary
- `openFlightPageInternal` unconditionally set `_flightDetails` to `Async.Error("FlightAware API is not configured...")` before opening the external URL, even when the API was configured and a successful lookup was in state
- On return from the browser, users saw a false "not configured" error replacing what was a successful flight details view
- Fix: remove the state mutation from `openFlightPageInternal` — the URL opening is self-explanatory, and existing state should be preserved across the browser round-trip

## Test plan
- [ ] Updated `openFlightPage sets error message before opening URL` → `openFlightPage does not change flightDetails state` to assert the correct behavior
- [ ] All `AircraftViewModelTest` tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.ai/claude-code)