### PR TITLE
Remove stale commented-out planes_count string resource

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="show_receiver_locations_title">Show receiver locations</string>
     <string name="show_receiver_locations_description">Display a marker for each configured server's location on the map</string>
     <string name="planes_count">%1$d planes</string>
-    <!--    <string name="planes_count">planes</string>-->
     <string name="user_location_content_description">User Location</string>
     <string name="fit_to_aircraft">Fit map to aircraft</string>
     <string name="follow_aircraft">Follow</string>


### PR DESCRIPTION
## Summary
- Investigated the stringResource format-arg bug noted in Overlay.kt (#143)
- Confirmed no bug exists: `stringResource(Res.string.planes_count, numberOfPlanes)` with `%1$d` format is correct Compose Multiplatform behavior
- Overlay.kt stale comment was already removed by the map-providers PR; removed the remaining commented-out `planes_count` variant from strings.xml

## Test plan
- [ ] Build succeeds; no functional change

Closes #143

🤖 Generated with [Claude Code](https://claude.ai/claude-code)