### PR TITLE
Add mapProviderId param to mockSettings() test helper

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
@@ -5,6 +5,7 @@ import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.model.Flight
 import com.jordankurtz.piawaremobile.model.FlightAirportRef
 import com.jordankurtz.piawaremobile.model.Receiver
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.settings.Server
 import com.jordankurtz.piawaremobile.settings.ServerType
 import com.jordankurtz.piawaremobile.settings.Settings
@@ -23,6 +24,7 @@ fun mockSettings(
     openUrlsExternally: Boolean = false,
     enableFlightAwareApi: Boolean = false,
     flightAwareApiKey: String = "",
+    mapProviderId: String = TileProviders.OPENSTREETMAP.id,
 ): Settings =
     Settings(
         servers = servers,
@@ -36,6 +38,7 @@ fun mockSettings(
         openUrlsExternally = openUrlsExternally,
         enableFlightAwareApi = enableFlightAwareApi,
         flightAwareApiKey = flightAwareApiKey,
+        mapProviderId = mapProviderId,
     )
 
 fun mockServer(


### PR DESCRIPTION
## Summary
- `mockSettings()` was missing a `mapProviderId` parameter, making it impossible for tests to render composables with a non-OSM provider
- Adds `mapProviderId: String = TileProviders.OPENSTREETMAP.id` with the same default as the production `Settings` data class

## Test plan
- [ ] All unit and desktop UI tests pass (no existing tests affected)

Closes #142

🤖 Generated with [Claude Code](https://claude.ai/claude-code)