### PR TITLE
Fix catch(Exception) swallowing CancellationException in suspend functions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareApiImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareApiImpl.kt
@@ -22,8 +22,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
             val response: PiAwareResponse =
                 httpClient.get("http://$host/data/aircraft.json").body<PiAwareResponse>()
             response.aircraft
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft", e)
             emptyList()
         }
@@ -33,8 +34,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
         return try {
             httpClient.get("http://$host/db/aircraft_types/icao_aircraft_types.json")
                 .body<Map<String, ICAOAircraftType>>()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft types", e)
             emptyMap()
         }
@@ -50,8 +52,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
                 httpClient.get(
                     key,
                 ).body<JsonObject>().also { aircraftInfoMap[key] = it }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                if (e is CancellationException) throw e
                 Logger.e("Error fetching aircraft info", e)
                 null
             }
@@ -62,8 +65,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
         return try {
             httpClient.get("http://$host/data/receiver.json")
                 .body<Receiver>()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Failed to get dump1090 receiver info", e)
             null
         }
@@ -73,8 +77,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
         return try {
             httpClient.get("http://$host/data-978/receiver.json")
                 .body<Receiver>()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Failed to get dump978 receiver info", e)
             null
         }
@@ -86,8 +91,9 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
     ): PiAwareResponse? {
         return try {
             httpClient.get("http://$host/data/history_$index.json").body<PiAwareResponse>()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching history file $index", e)
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareApiImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareApiImpl.kt
@@ -9,6 +9,7 @@ import com.jordankurtz.piawaremobile.model.Receiver
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 import org.koin.core.annotation.Single
 
@@ -22,6 +23,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
                 httpClient.get("http://$host/data/aircraft.json").body<PiAwareResponse>()
             response.aircraft
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft", e)
             emptyList()
         }
@@ -32,6 +34,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
             httpClient.get("http://$host/db/aircraft_types/icao_aircraft_types.json")
                 .body<Map<String, ICAOAircraftType>>()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft types", e)
             emptyMap()
         }
@@ -48,6 +51,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
                     key,
                 ).body<JsonObject>().also { aircraftInfoMap[key] = it }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e("Error fetching aircraft info", e)
                 null
             }
@@ -59,6 +63,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
             httpClient.get("http://$host/data/receiver.json")
                 .body<Receiver>()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Failed to get dump1090 receiver info", e)
             null
         }
@@ -69,6 +74,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
             httpClient.get("http://$host/data-978/receiver.json")
                 .body<Receiver>()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Failed to get dump978 receiver info", e)
             null
         }
@@ -81,6 +87,7 @@ class PiAwareApiImpl(private val httpClient: HttpClient) : PiAwareApi {
         return try {
             httpClient.get("http://$host/data/history_$index.json").body<PiAwareResponse>()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching history file $index", e)
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
@@ -25,8 +25,9 @@ class ReadsbDataSource(
             val response: PiAwareResponse =
                 httpClient.get("http://${server.address}/data/aircraft.json").body()
             response.aircraft
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft from readsb server ${server.address}", e)
             emptyList()
         }
@@ -35,8 +36,9 @@ class ReadsbDataSource(
     override suspend fun getReceiverInfo(server: Server): Receiver? {
         return try {
             httpClient.get("http://${server.address}/data/receiver.json").body()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching receiver info from readsb server ${server.address}", e)
             null
         }
@@ -50,8 +52,9 @@ class ReadsbDataSource(
     override suspend fun getAircraftTypes(server: Server): Map<String, ICAOAircraftType> {
         return try {
             httpClient.get("http://${server.address}/db/aircraft_types/icao_aircraft_types.json").body()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft types from readsb server ${server.address}", e)
             emptyMap()
         }
@@ -63,8 +66,9 @@ class ReadsbDataSource(
     ): JsonObject? {
         return try {
             httpClient.get("http://${server.address}/db/$bkey.json").body()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft info from readsb server ${server.address}", e)
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
@@ -10,6 +10,7 @@ import com.jordankurtz.piawaremobile.settings.Server
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 import org.koin.core.annotation.Single
 
@@ -25,6 +26,7 @@ class ReadsbDataSource(
                 httpClient.get("http://${server.address}/data/aircraft.json").body()
             response.aircraft
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft from readsb server ${server.address}", e)
             emptyList()
         }
@@ -34,6 +36,7 @@ class ReadsbDataSource(
         return try {
             httpClient.get("http://${server.address}/data/receiver.json").body()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching receiver info from readsb server ${server.address}", e)
             null
         }
@@ -48,6 +51,7 @@ class ReadsbDataSource(
         return try {
             httpClient.get("http://${server.address}/db/aircraft_types/icao_aircraft_types.json").body()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft types from readsb server ${server.address}", e)
             emptyMap()
         }
@@ -60,6 +64,7 @@ class ReadsbDataSource(
         return try {
             httpClient.get("http://${server.address}/db/$bkey.json").body()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Error fetching aircraft info from readsb server ${server.address}", e)
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
@@ -12,6 +12,7 @@ import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.model.ReceiverType
 import com.jordankurtz.piawaremobile.settings.Server
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -44,6 +45,7 @@ class AircraftRepoImpl(
                                 val dataSource = dataSourceFactory.getDataSource(server.type)
                                 dataSource.getAircraft(server).map { aircraft -> aircraft to server }
                             } catch (e: Exception) {
+                                if (e is CancellationException) throw e
                                 Logger.e("Failed to fetch aircraft from server $server", e)
                                 emptyList()
                             }
@@ -114,6 +116,7 @@ class AircraftRepoImpl(
                 )
             Async.Success(response)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Failed to fetch flight for ident $ident", e)
             Async.Error("Failed to fetch flight for ident $ident", e)
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
@@ -44,8 +44,9 @@ class AircraftRepoImpl(
                             try {
                                 val dataSource = dataSourceFactory.getDataSource(server.type)
                                 dataSource.getAircraft(server).map { aircraft -> aircraft to server }
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
-                                if (e is CancellationException) throw e
                                 Logger.e("Failed to fetch aircraft from server $server", e)
                                 emptyList()
                             }
@@ -115,8 +116,9 @@ class AircraftRepoImpl(
                     ident = ident,
                 )
             Async.Success(response)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Failed to fetch flight for ident $ident", e)
             Async.Error("Failed to fetch flight for ident $ident", e)
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/impl/LoadHistoryUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/impl/LoadHistoryUseCaseImpl.kt
@@ -4,6 +4,7 @@ import com.jordankurtz.logger.Logger
 import com.jordankurtz.piawaremobile.aircraft.repo.AircraftRepo
 import com.jordankurtz.piawaremobile.aircraft.usecase.LoadHistoryUseCase
 import com.jordankurtz.piawaremobile.settings.Server
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -22,6 +23,7 @@ class LoadHistoryUseCaseImpl(
                     try {
                         aircraftRepo.fetchAndMergeHistory(server)
                     } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         Logger.e("Failed to fetch history from server $server", e)
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/impl/LoadHistoryUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/usecase/impl/LoadHistoryUseCaseImpl.kt
@@ -22,8 +22,9 @@ class LoadHistoryUseCaseImpl(
                 async {
                     try {
                         aircraftRepo.fetchAndMergeHistory(server)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
-                        if (e is CancellationException) throw e
                         Logger.e("Failed to fetch history from server $server", e)
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ConfigurableTileProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ConfigurableTileProvider.kt
@@ -5,6 +5,7 @@ import com.jordankurtz.piawaremobile.map.cache.TileCache
 import com.jordankurtz.piawaremobile.map.debug.TileCacheStatsTracker
 import com.jordankurtz.piawaremobile.map.offline.OfflineTileStore
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.io.Buffer
 import kotlinx.io.RawSource
@@ -48,6 +49,7 @@ class ConfigurableTileProvider(
             statsTracker.recordNetworkFetch()
             Buffer().apply { write(bytes) }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Failed to load tile", e)
             statsTracker.recordError()
             null

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ConfigurableTileProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ConfigurableTileProvider.kt
@@ -48,8 +48,9 @@ class ConfigurableTileProvider(
             tileCache.put(zoomLvl, col, row, configFlow.value.id, bytes)
             statsTracker.recordNetworkFetch()
             Buffer().apply { write(bytes) }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Failed to load tile", e)
             statsTracker.recordError()
             null

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/cache/FileTileCache.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/cache/FileTileCache.kt
@@ -1,6 +1,7 @@
 package com.jordankurtz.piawaremobile.map.cache
 
 import com.jordankurtz.logger.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -68,6 +69,7 @@ class FileTileCache(
                 try {
                     cacheFileSystem.read(tileKey)
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.e("Failed to read cached tile $tileKey", e)
                     null
                 }
@@ -118,6 +120,7 @@ class FileTileCache(
                 )
                 Logger.d("Cached tile: $tileKey (${data.size} bytes)")
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e("Failed to write cached tile $tileKey", e)
                 return@withContext
             }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/cache/FileTileCache.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/cache/FileTileCache.kt
@@ -68,8 +68,9 @@ class FileTileCache(
             val bytes =
                 try {
                     cacheFileSystem.read(tileKey)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
-                    if (e is CancellationException) throw e
                     Logger.e("Failed to read cached tile $tileKey", e)
                     null
                 }
@@ -119,8 +120,9 @@ class FileTileCache(
                     now,
                 )
                 Logger.d("Cached tile: $tileKey (${data.size} bytes)")
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                if (e is CancellationException) throw e
                 Logger.e("Failed to write cached tile $tileKey", e)
                 return@withContext
             }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineDownloadEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineDownloadEngine.kt
@@ -128,8 +128,9 @@ class OfflineDownloadEngine(
                     header("User-Agent", userAgent)
                 }
             if (response.status.isSuccess()) response.body() else null
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             Logger.e("Failed to download tile $zoom/$col/$row", e)
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineDownloadEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineDownloadEngine.kt
@@ -7,6 +7,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -128,6 +129,7 @@ class OfflineDownloadEngine(
                 }
             if (response.status.isSuccess()) response.body() else null
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e("Failed to download tile $zoom/$col/$row", e)
             null
         }


### PR DESCRIPTION
## Summary
- Audited all `catch (e: Exception)` blocks in suspend functions and added `if (e is CancellationException) throw e` to each site
- Without this, coroutine cancellation is silently swallowed — cancelled coroutines continue running instead of terminating, breaking structured concurrency

## Fixed sites
| File | Context |
|---|---|
| `PiAwareApiImpl` | 6 network call catch blocks |
| `ReadsbDataSource` | 4 network call catch blocks |
| `AircraftRepoImpl` | `getAircraftWithServers` async block, `lookupFlight` |
| `LoadHistoryUseCaseImpl` | async block inside `coroutineScope` |
| `ConfigurableTileProvider` | `getTileStream` tile fetch |
| `FileTileCache` | `get` (disk read), `put` (disk write) |
| `OfflineDownloadEngine` | `fetchTile` |

## Not changed
- `OfflineMapsViewModel`: already has a dedicated `catch (CancellationException)` block before the generic catch ✓
- `OfflineDownloadEngine.downloadRegion`: already re-throws via `throw e` ✓

## Test plan
- [ ] All unit and desktop UI tests pass
- [ ] ktlint passes

Closes #119

🤖 Generated with [Claude Code](https://claude.ai/claude-code)