### PR TITLE
Add test coverage for isDarkMap overlay color

### DIFF
--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/extensions/ModelExtensionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/extensions/ModelExtensionsTest.kt
@@ -1,0 +1,20 @@
+package com.jordankurtz.piawaremobile.extensions
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.jordankurtz.piawaremobile.map.TileProviders
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ModelExtensionsTest {
+    @Test
+    fun overlayColorIsWhiteForDarkProvider() {
+        assertEquals(Color.White, TileProviders.CARTO_DARK_ALL.overlayColor)
+    }
+
+    @Test
+    fun overlayColorIsBlackForLightProvider() {
+        assertEquals(Color.Black, TileProviders.OPENSTREETMAP.overlayColor)
+    }
+}


### PR DESCRIPTION
## Summary
- `overlayColor` extension property was used by Compose rendering with no assertions verifying the light/dark color behavior
- Added two unit tests: `Color.White` for dark providers (`CARTO_DARK_ALL`) and `Color.Black` for light providers (`OPENSTREETMAP`)
- Tests live in `desktopTest` because `TileProviderConfig` requires `StringResource` from Compose Resources, which is unavailable in `commonTest` on the Android unit test JVM

## Test plan
- [ ] `desktopTest` passes

Closes #144

🤖 Generated with [Claude Code](https://claude.ai/claude-code)