### PR TITLE
Fix: persist initial region status in insertOfflineRegion

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
@@ -13,6 +13,6 @@ data class OfflineRegion(
     val createdAt: Long,
     val tileCount: Long = 0L,
     val sizeBytes: Long = 0L,
-    val status: DownloadStatus = DownloadStatus.COMPLETE,
+    val status: DownloadStatus = DownloadStatus.DOWNLOADING,
     val downloadedTileCount: Long = 0L,
 )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
@@ -22,6 +22,7 @@ class SqlDelightOfflineTileStore(
                     max_lon = region.maxLon,
                     provider_id = region.providerId,
                     created_at = region.createdAt,
+                    status = region.status.name,
                 )
                 queries.lastInsertedRegionId().executeAsOne()
             }

--- a/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/TileCache.sq
+++ b/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/TileCache.sq
@@ -109,8 +109,8 @@ DELETE FROM tile WHERE zoom_level = ? AND col = ? AND row = ? AND provider_id = 
 
 -- Offline region queries
 insertOfflineRegion:
-INSERT INTO offline_region (name, min_zoom, max_zoom, min_lat, max_lat, min_lon, max_lon, provider_id, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO offline_region (name, min_zoom, max_zoom, min_lat, max_lat, min_lon, max_lon, provider_id, created_at, status)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 lastInsertedRegionId:
 SELECT last_insert_rowid();

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModelTest.kt
@@ -50,6 +50,7 @@ class OfflineMapsViewModelTest {
             maxLon = -74.0,
             providerId = "openstreetmap",
             createdAt = 1000L,
+            status = DownloadStatus.COMPLETE,
         )
 
     @BeforeTest

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/OfflineMapsScreenTest.kt
@@ -58,6 +58,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 2400L,
                         sizeBytes = 42L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                     OfflineRegion(
                         id = 2L,
@@ -72,6 +73,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 5000L,
                         sizeBytes = 128L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                 )
             setContent {
@@ -102,6 +104,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 2400L,
                         sizeBytes = 42L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                     OfflineRegion(
                         id = 2L,
@@ -116,6 +119,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 5000L,
                         sizeBytes = 128L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                 )
             setContent {
@@ -146,6 +150,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 2400L,
                         sizeBytes = 42L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                 )
             setContent {
@@ -187,6 +192,7 @@ class OfflineMapsScreenTest {
                         createdAt = 1700000000000L,
                         tileCount = 2400L,
                         sizeBytes = 42L * 1024 * 1024,
+                        status = DownloadStatus.COMPLETE,
                     ),
                 )
             setContent {
@@ -216,6 +222,7 @@ class OfflineMapsScreenTest {
                     createdAt = 1700000000000L,
                     tileCount = 2400L,
                     sizeBytes = 42L * 1024 * 1024,
+                    status = DownloadStatus.COMPLETE,
                 )
             setContent {
                 OfflineMapsScreen(

--- a/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
@@ -320,17 +320,19 @@ class SqlDelightOfflineTileStoreTest {
         )
     }
 
-    private fun baseRegion(name: String) =
-        OfflineRegion(
-            name = name,
-            minZoom = 8,
-            maxZoom = 12,
-            minLat = 0.0,
-            maxLat = 1.0,
-            minLon = 0.0,
-            maxLon = 1.0,
-            providerId = "osm",
-            createdAt = 1000L,
-            status = status,
-        )
+    private fun baseRegion(
+        name: String,
+        status: DownloadStatus = DownloadStatus.DOWNLOADING,
+    ) = OfflineRegion(
+        name = name,
+        minZoom = 8,
+        maxZoom = 12,
+        minLat = 0.0,
+        maxLat = 1.0,
+        minLon = 0.0,
+        maxLon = 1.0,
+        providerId = "osm",
+        createdAt = 1000L,
+        status = status,
+    )
 }

--- a/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
@@ -69,6 +69,27 @@ class SqlDelightOfflineTileStoreTest {
         }
 
     @Test
+    fun `saveRegion persists the initial status`() =
+        runTest(testDispatcher) {
+            val region =
+                OfflineRegion(
+                    name = "Pending",
+                    minZoom = 8,
+                    maxZoom = 12,
+                    minLat = 0.0,
+                    maxLat = 1.0,
+                    minLon = 0.0,
+                    maxLon = 1.0,
+                    providerId = "osm",
+                    createdAt = 1000L,
+                    status = DownloadStatus.DOWNLOADING,
+                )
+            val id = store.saveRegion(region)
+            val saved = store.getRegion(id)
+            assertEquals(DownloadStatus.DOWNLOADING, saved?.status)
+        }
+
+    @Test
     fun `getRegion returns null for unknown id`() =
         runTest(testDispatcher) {
             assertNull(store.getRegion(999L))
@@ -253,7 +274,7 @@ class SqlDelightOfflineTileStoreTest {
     @Test
     fun `resetStuckDownloads leaves COMPLETE, FAILED, and PARTIAL regions unchanged`() =
         runTest(testDispatcher) {
-            val completeId = store.saveRegion(baseRegion("Complete"))
+            val completeId = store.saveRegion(baseRegion("Complete", status = DownloadStatus.COMPLETE))
             val failedId = store.saveRegion(baseRegion("Failed"))
             val partialId = store.saveRegion(baseRegion("Partial"))
 
@@ -310,5 +331,6 @@ class SqlDelightOfflineTileStoreTest {
             maxLon = 1.0,
             providerId = "osm",
             createdAt = 1000L,
+            status = status,
         )
 }


### PR DESCRIPTION
## Summary

- `insertOfflineRegion` now explicitly persists the `status` column, so a new region can never transiently appear as `COMPLETE` in the database
- Changed `OfflineRegion.status` default from `COMPLETE` to `DOWNLOADING` so in-memory construction before the first DB write also reflects the correct state
- Updated all test fixtures that relied on the old default to use explicit `status = DownloadStatus.COMPLETE`
- Added `saveRegion persists the initial status` test to cover the fix

## Test plan

- [x] `./gradlew :composeApp:testDebugUnitTest` — all unit tests pass
- [x] `./gradlew :composeApp:desktopTest` — all desktop UI tests pass
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew detekt` — passes

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)