### PR TITLE
Add mapProviderId param to mockSettings() test helper

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/MockData.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.testutil
 
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.model.Flight
@@ -23,6 +24,7 @@ fun mockSettings(
     openUrlsExternally: Boolean = false,
     enableFlightAwareApi: Boolean = false,
     flightAwareApiKey: String = "",
+    mapProviderId: String = TileProviders.OPENSTREETMAP.id,
 ): Settings =
     Settings(
         servers = servers,
@@ -36,6 +38,7 @@ fun mockSettings(
         openUrlsExternally = openUrlsExternally,
         enableFlightAwareApi = enableFlightAwareApi,
         flightAwareApiKey = flightAwareApiKey,
+        mapProviderId = mapProviderId,
     )
 
 fun mockServer(


### PR DESCRIPTION
## Summary

- Added `mapProviderId: String = TileProviders.OPENSTREETMAP.id` parameter to `mockSettings()` so tests can specify a non-default tile provider without constructing `Settings` directly

## Test plan

- [x] `./gradlew :composeApp:testDebugUnitTest` — all unit tests pass
- [x] `./gradlew :composeApp:desktopTest` — all desktop UI tests pass
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew detekt` — passes

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)