### PR TITLE
Add unit tests for overlayColor dark/light map provider logic

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/extensions/ModelExtensionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/extensions/ModelExtensionsTest.kt
@@ -1,0 +1,18 @@
+package com.jordankurtz.piawaremobile.extensions
+
+import androidx.compose.ui.graphics.Color
+import com.jordankurtz.piawaremobile.map.TileProviders
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModelExtensionsTest {
+    @Test
+    fun `overlayColor is Black for light map provider`() {
+        assertEquals(Color.Black, TileProviders.OPENSTREETMAP.overlayColor)
+    }
+
+    @Test
+    fun `overlayColor is White for dark map provider`() {
+        assertEquals(Color.White, TileProviders.CARTO_DARK_ALL.overlayColor)
+    }
+}


### PR DESCRIPTION
## Summary

- Added `ModelExtensionsTest` with two unit tests for `TileProviderConfig.overlayColor`:
  - Light map provider (`isDarkMap = false`) → `Color.Black`
  - Dark map provider (`isDarkMap = true`) → `Color.White`
- Tests live in `commonTest` and run without a Compose runtime since `overlayColor` is a pure extension property

## Test plan

- [x] `./gradlew :composeApp:testDebugUnitTest` — all unit tests pass
- [x] `./gradlew :composeApp:desktopTest` — all desktop UI tests pass
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew detekt` — passes

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)