### PR TITLE
Add jvmToolchain(17) to all modules for consistent JDK management

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
         freeCompilerArgs.add("-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi")

--- a/console-logger/build.gradle.kts
+++ b/console-logger/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }

--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {

--- a/sentry-logger/build.gradle.kts
+++ b/sentry-logger/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }


### PR DESCRIPTION
## Summary

- Added `jvmToolchain(17)` to all four `kotlin { }` blocks (composeApp, logger, console-logger, sentry-logger)
- Gradle can now auto-provision JDK 17 instead of relying on the environment having it pre-installed
- Aligns with the `temurin` JDK 17 already provisioned by `actions/setup-java` in CI — the CI step now acts as a cache optimization rather than the sole source of truth
- Existing `jvmTarget = JVM_11` and Android `compileOptions` are unchanged — the toolchain controls which JDK runs the compiler, not the bytecode output version

## Test plan

- [x] `./gradlew :composeApp:testDebugUnitTest` — all unit tests pass
- [x] `./gradlew :composeApp:desktopTest` — all desktop UI tests pass
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew detekt` — passes

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)