### PR TITLE
Improve unit test coverage: SettingsViewModel, AircraftViewModel, LocationViewModel

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
@@ -11,6 +11,7 @@ import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.AircraftTrail
 import com.jordankurtz.piawaremobile.model.AircraftWithServers
 import com.jordankurtz.piawaremobile.model.Async
+import com.jordankurtz.piawaremobile.model.Location
 import com.jordankurtz.piawaremobile.settings.Server
 import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
@@ -409,5 +410,34 @@ class AircraftViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             assertEquals(stateBefore, viewModel.flightDetails.value)
+        }
+
+    @Test
+    fun `showReceiverLocations true loads receiver locations for all servers`() =
+        runTest {
+            val server = servers.first()
+            val location = Location(latitude = 47.6, longitude = -122.3)
+            val settingsWithLocations = settings.copy(showReceiverLocations = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settingsWithLocations))
+            everySuspend { getReceiverLocationUseCase(server) } returns location
+
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(mapOf(server to location), viewModel.receiverLocations.value)
+        }
+
+    @Test
+    fun `showReceiverLocations true filters out null locations`() =
+        runTest {
+            val server = servers.first()
+            val settingsWithLocations = settings.copy(showReceiverLocations = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settingsWithLocations))
+            everySuspend { getReceiverLocationUseCase(server) } returns null
+
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(emptyMap(), viewModel.receiverLocations.value)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -39,6 +40,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @ExperimentalCoroutinesApi
 class AircraftViewModelTest {
@@ -439,5 +441,40 @@ class AircraftViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             assertEquals(emptyMap(), viewModel.receiverLocations.value)
+        }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultTickerFlowTest {
+    @Test
+    fun `defaultTickerFlow emits Unit on each interval`() =
+        runTest {
+            val flow = defaultTickerFlow(100.milliseconds)
+            val emissions = mutableListOf<Unit>()
+
+            val job = launch {
+                flow.collect { emissions.add(it) }
+            }
+
+            testScheduler.advanceTimeBy(250)
+            job.cancel()
+
+            assertEquals(3, emissions.size)
+        }
+
+    @Test
+    fun `defaultTickerFlow respects custom interval`() =
+        runTest {
+            val flow = defaultTickerFlow(50.milliseconds)
+            val emissions = mutableListOf<Unit>()
+
+            val job = launch {
+                flow.collect { emissions.add(it) }
+            }
+
+            testScheduler.advanceTimeBy(175)
+            job.cancel()
+
+            assertEquals(4, emissions.size)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/AircraftViewModelTest.kt
@@ -452,9 +452,10 @@ class DefaultTickerFlowTest {
             val flow = defaultTickerFlow(100.milliseconds)
             val emissions = mutableListOf<Unit>()
 
-            val job = launch {
-                flow.collect { emissions.add(it) }
-            }
+            val job =
+                launch {
+                    flow.collect { emissions.add(it) }
+                }
 
             testScheduler.advanceTimeBy(250)
             job.cancel()
@@ -468,9 +469,10 @@ class DefaultTickerFlowTest {
             val flow = defaultTickerFlow(50.milliseconds)
             val emissions = mutableListOf<Unit>()
 
-            val job = launch {
-                flow.collect { emissions.add(it) }
-            }
+            val job =
+                launch {
+                    flow.collect { emissions.add(it) }
+                }
 
             testScheduler.advanceTimeBy(175)
             job.cancel()

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/location/LocationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/location/LocationViewModelTest.kt
@@ -1,0 +1,204 @@
+package com.jordankurtz.piawaremobile.location
+
+import app.cash.turbine.test
+import com.jordankurtz.piawaremobile.model.Async
+import com.jordankurtz.piawaremobile.model.Location
+import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
+import com.jordankurtz.piawaremobile.testutil.FakeLocationService
+import com.jordankurtz.piawaremobile.testutil.mockSettings
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class LocationViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var locationService: FakeLocationService
+    private lateinit var loadSettingsUseCase: LoadSettingsUseCase
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        locationService = FakeLocationService()
+        loadSettingsUseCase = mock()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): LocationViewModel =
+        LocationViewModel(
+            locationService = locationService,
+            loadSettingsUseCase = loadSettingsUseCase,
+        )
+
+    @Test
+    fun `showUserLocationOnMap true requests location permission`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1, locationService.requestPermissionsCallCount)
+        }
+
+    @Test
+    fun `centerMapOnUserOnStart true requests location permission`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = false, centerMapOnUserOnStart = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1, locationService.requestPermissionsCallCount)
+        }
+
+    @Test
+    fun `both showUserLocationOnMap and centerMapOnUserOnStart true requests permission twice`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(2, locationService.requestPermissionsCallCount)
+        }
+
+    @Test
+    fun `permission granted transitions state to TrackingLocation`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+
+            assertEquals(LocationState.TrackingLocation, vm.locationState.value)
+        }
+
+    @Test
+    fun `permission denied transitions state to PermissionDenied`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.denyPermission()
+
+            assertEquals(LocationState.PermissionDenied, vm.locationState.value)
+        }
+
+    @Test
+    fun `location updates are reflected in currentLocation`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+            val location = Location(latitude = 47.6, longitude = -122.3)
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+            locationService.emitLocation(location)
+
+            assertEquals(location, vm.currentLocation.value)
+        }
+
+    @Test
+    fun `stopLocationUpdates resets state to Idle and clears location`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+            val location = Location(latitude = 47.6, longitude = -122.3)
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+            locationService.emitLocation(location)
+
+            vm.stopLocationUpdates()
+
+            assertEquals(LocationState.Idle, vm.locationState.value)
+            assertEquals(null, vm.currentLocation.value)
+            assertTrue(locationService.stopLocationUpdatesCalled)
+        }
+
+    @Test
+    fun `recenterMap emits on first location update when centerMapOnUserOnStart is true`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = false, centerMapOnUserOnStart = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+            val location = Location(latitude = 47.6, longitude = -122.3)
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+
+            vm.recenterMap.test {
+                locationService.emitLocation(location)
+                testDispatcher.scheduler.advanceUntilIdle()
+                assertEquals(location, awaitItem())
+            }
+        }
+
+    @Test
+    fun `recenterMap does not emit on subsequent location updates`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = false, centerMapOnUserOnStart = true)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+            val location1 = Location(latitude = 47.6, longitude = -122.3)
+            val location2 = Location(latitude = 48.0, longitude = -123.0)
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+
+            vm.recenterMap.test {
+                locationService.emitLocation(location1)
+                testDispatcher.scheduler.advanceUntilIdle()
+                assertEquals(location1, awaitItem())
+
+                locationService.emitLocation(location2)
+                testDispatcher.scheduler.advanceUntilIdle()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `recenterMap does not emit when showUserLocationOnMap true but centerMapOnUserOnStart false`() =
+        runTest {
+            val settings = mockSettings(showUserLocationOnMap = true, centerMapOnUserOnStart = false)
+            every { loadSettingsUseCase() } returns flowOf(Async.Success(settings))
+            val location = Location(latitude = 47.6, longitude = -122.3)
+
+            val vm = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            locationService.grantPermission()
+
+            vm.recenterMap.test {
+                locationService.emitLocation(location)
+                testDispatcher.scheduler.advanceUntilIdle()
+                expectNoEvents()
+            }
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.jordankurtz.piawaremobile.settings
 
 import app.cash.turbine.test
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.usecase.SettingsService
 import dev.mokkery.answering.returns
@@ -62,6 +63,7 @@ class SettingsViewModelTest {
         everySuspend { settingsService.setOpenUrlsExternally(any()) } returns Unit
         everySuspend { settingsService.setEnableFlightAwareApi(any()) } returns Unit
         everySuspend { settingsService.setFlightAwareApiKey(any()) } returns Unit
+        everySuspend { settingsService.setMapProviderId(any()) } returns Unit
 
         viewModel = SettingsViewModel(settingsService)
     }
@@ -196,5 +198,52 @@ class SettingsViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setOpenUrlsExternally(true) }
+        }
+
+    @Test
+    fun `updateTrailDisplayMode delegates to settings service`() =
+        runTest {
+            viewModel.updateTrailDisplayMode(TrailDisplayMode.ALL)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setTrailDisplayMode(TrailDisplayMode.ALL) }
+        }
+
+    @Test
+    fun `updateShowMinimapTrails delegates to settings service`() =
+        runTest {
+            viewModel.updateShowMinimapTrails(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setShowMinimapTrails(true) }
+        }
+
+    @Test
+    fun `updateEnableFlightAwareApi delegates to settings service`() =
+        runTest {
+            viewModel.updateEnableFlightAwareApi(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setEnableFlightAwareApi(true) }
+        }
+
+    @Test
+    fun `updateFlightAwareApiKey delegates to settings service`() =
+        runTest {
+            viewModel.updateFlightAwareApiKey("my_api_key")
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) { settingsService.setFlightAwareApiKey("my_api_key") }
+        }
+
+    @Test
+    fun `updateMapProvider delegates provider id to settings service`() =
+        runTest {
+            viewModel.updateMapProvider(TileProviders.OPENSTREETMAP)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verifySuspend(
+                mode = VerifyMode.exactly(1),
+            ) { settingsService.setMapProviderId(TileProviders.OPENSTREETMAP.id) }
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/FakeLocationService.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/testutil/FakeLocationService.kt
@@ -1,0 +1,31 @@
+package com.jordankurtz.piawaremobile.testutil
+
+import com.jordankurtz.piawaremobile.location.LocationService
+import com.jordankurtz.piawaremobile.model.Location
+
+class FakeLocationService : LocationService {
+    private val permissionCallbacks = mutableListOf<(Boolean) -> Unit>()
+    private var locationCallback: ((Location) -> Unit)? = null
+
+    var requestPermissionsCallCount = 0
+    var stopLocationUpdatesCalled = false
+
+    fun grantPermission() = permissionCallbacks.forEach { it(true) }
+
+    fun denyPermission() = permissionCallbacks.forEach { it(false) }
+
+    fun emitLocation(location: Location) = locationCallback?.invoke(location)
+
+    override fun requestPermissions(onResult: (Boolean) -> Unit) {
+        requestPermissionsCallCount++
+        permissionCallbacks.add(onResult)
+    }
+
+    override fun startLocationUpdates(onLocationUpdate: (Location) -> Unit) {
+        locationCallback = onLocationUpdate
+    }
+
+    override fun stopLocationUpdates() {
+        stopLocationUpdatesCalled = true
+    }
+}


### PR DESCRIPTION
Closes #55

## Summary
- Add 5 tests to `SettingsViewModelTest` for previously uncovered update methods (`updateTrailDisplayMode`, `updateShowMinimapTrails`, `updateEnableFlightAwareApi`, `updateFlightAwareApiKey`, `updateMapProvider`)
- Add 2 tests to `AircraftViewModelTest` for `loadReceiverLocations` (location returned and null-filtered paths)
- Add `FakeLocationService` test helper and 9 tests in new `LocationViewModelTest` covering permission flow, state transitions, location updates, stop, and recenter logic
- Add 2 tests for `defaultTickerFlow` in `AircraftViewModelTest`

## Test Plan
- [ ] `./gradlew :composeApp:testDebugUnitTest` passes
- [ ] `./gradlew :composeApp:desktopTest` passes