### PR TITLE
Implement readsb trace API for aircraft trail history (#115)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/AircraftDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/AircraftDataSource.kt
@@ -1,15 +1,13 @@
 package com.jordankurtz.piawaremobile.aircraft.api
 
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.settings.Server
 import kotlinx.serialization.json.JsonObject
 
 interface AircraftDataSource {
-    val supportsHistory: Boolean
-
     suspend fun getAircraft(server: Server): List<Aircraft>
 
     suspend fun getReceiverInfo(server: Server): Receiver?
@@ -23,8 +21,5 @@ interface AircraftDataSource {
         bkey: String,
     ): JsonObject?
 
-    suspend fun getHistory(
-        server: Server,
-        index: Int,
-    ): PiAwareResponse?
+    suspend fun fetchTrails(server: Server): Map<String, List<AircraftPosition>>
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/PiAwareDataSource.kt
@@ -3,10 +3,15 @@ package com.jordankurtz.piawaremobile.aircraft.api.impl
 import com.jordankurtz.piawaremobile.aircraft.api.AircraftDataSource
 import com.jordankurtz.piawaremobile.aircraft.api.PiAwareApi
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.settings.Server
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonObject
 import org.koin.core.annotation.Single
 
@@ -14,8 +19,6 @@ import org.koin.core.annotation.Single
 class PiAwareDataSource(
     private val piAwareApi: PiAwareApi,
 ) : AircraftDataSource {
-    override val supportsHistory: Boolean = true
-
     override suspend fun getAircraft(server: Server): List<Aircraft> {
         return piAwareApi.getAircraft(server.address)
     }
@@ -39,10 +42,51 @@ class PiAwareDataSource(
         return piAwareApi.getAircraftInfo(server.address, bkey)
     }
 
-    override suspend fun getHistory(
-        server: Server,
+    override suspend fun fetchTrails(server: Server): Map<String, List<AircraftPosition>> {
+        val receiver = piAwareApi.getDump1090ReceiverInfo(server.address) ?: return emptyMap()
+        val historyCount = receiver.history ?: return emptyMap()
+        if (historyCount <= 0) return emptyMap()
+
+        return coroutineScope {
+            (0 until historyCount).map { index ->
+                async { fetchHistoryWithRetry(server.address, index) }
+            }.awaitAll()
+                .filterNotNull()
+                .toTrails()
+        }
+    }
+
+    private suspend fun fetchHistoryWithRetry(
+        host: String,
         index: Int,
+        maxRetries: Int = 3,
     ): PiAwareResponse? {
-        return piAwareApi.getHistoryFile(server.address, index)
+        repeat(maxRetries) { attempt ->
+            val result = piAwareApi.getHistoryFile(host, index)
+            if (result != null) return result
+            if (attempt < maxRetries - 1) delay((attempt + 1) * 500L)
+        }
+        return null
+    }
+
+    private fun List<PiAwareResponse>.toTrails(): Map<String, List<AircraftPosition>> {
+        val result = mutableMapOf<String, MutableList<AircraftPosition>>()
+        forEach { response ->
+            val snapshotTime = response.now ?: return@forEach
+            response.aircraft
+                .filter { it.hasPosition }
+                .forEach { aircraft ->
+                    val positionAge = aircraft.seenPos ?: aircraft.seen ?: 0f
+                    result.getOrPut(aircraft.hex) { mutableListOf() }.add(
+                        AircraftPosition(
+                            latitude = aircraft.lat,
+                            longitude = aircraft.lon,
+                            altitude = aircraft.altBaro,
+                            timestamp = snapshotTime - positionAge,
+                        ),
+                    )
+                }
+        }
+        return result
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
@@ -16,9 +16,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.annotation.Single
 
 @Single
@@ -119,26 +117,12 @@ class ReadsbDataSource(
         val result = mutableMapOf<String, MutableList<AircraftPosition>>()
         forEach { response ->
             val positions =
-                response.trace.mapNotNull { entry ->
-                    val timeOffset =
-                        entry.getOrNull(0)?.jsonPrimitive?.content?.toDoubleOrNull()
-                            ?: return@mapNotNull null
-                    val lat =
-                        entry.getOrNull(1)?.jsonPrimitive?.content?.toDoubleOrNull()
-                            ?: return@mapNotNull null
-                    val lon =
-                        entry.getOrNull(2)?.jsonPrimitive?.content?.toDoubleOrNull()
-                            ?: return@mapNotNull null
-                    val altBaro =
-                        when (val altEl = entry.getOrNull(3)) {
-                            null, JsonNull -> null
-                            else -> altEl.jsonPrimitive.content
-                        }
+                response.trace.map { entry ->
                     AircraftPosition(
-                        latitude = lat,
-                        longitude = lon,
-                        altitude = altBaro,
-                        timestamp = response.timestamp + timeOffset,
+                        latitude = entry.latitude,
+                        longitude = entry.longitude,
+                        altitude = entry.altitude,
+                        timestamp = response.timestamp + entry.timeOffset,
                     )
                 }
             if (positions.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
@@ -6,20 +6,25 @@ import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
+import com.jordankurtz.piawaremobile.model.ReadsbTraceResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.settings.Server
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.annotation.Single
 
 @Single
 class ReadsbDataSource(
     private val httpClient: HttpClient,
 ) : AircraftDataSource {
-
     override suspend fun getAircraft(server: Server): List<Aircraft> {
         return try {
             val response: PiAwareResponse =
@@ -75,9 +80,71 @@ class ReadsbDataSource(
     }
 
     override suspend fun fetchTrails(server: Server): Map<String, List<AircraftPosition>> {
-        // readsb uses a trace API (/data/traces/) instead of history files.
-        // Trace API support will be added in a follow-up issue.
-        Logger.d("fetchTrails not yet supported for readsb server ${server.address}, use trace API instead")
-        return emptyMap()
+        val aircraft =
+            try {
+                httpClient.get("http://${server.address}/data/aircraft.json")
+                    .body<PiAwareResponse>().aircraft
+                    .filter { it.hasPosition }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e("Error fetching aircraft from readsb server ${server.address}", e)
+                return emptyMap()
+            }
+
+        return coroutineScope {
+            aircraft.map { plane ->
+                async { fetchTrace(server, plane.hex) }
+            }.awaitAll()
+                .filterNotNull()
+                .toTrails()
+        }
+    }
+
+    private suspend fun fetchTrace(
+        server: Server,
+        hex: String,
+    ): ReadsbTraceResponse? {
+        return try {
+            httpClient.get("http://${server.address}/data/traces/${hex.take(2)}/$hex.json").body()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.e("Error fetching trace for $hex from readsb server ${server.address}", e)
+            null
+        }
+    }
+
+    private fun List<ReadsbTraceResponse>.toTrails(): Map<String, List<AircraftPosition>> {
+        val result = mutableMapOf<String, MutableList<AircraftPosition>>()
+        forEach { response ->
+            val positions =
+                response.trace.mapNotNull { entry ->
+                    val timeOffset =
+                        entry.getOrNull(0)?.jsonPrimitive?.content?.toDoubleOrNull()
+                            ?: return@mapNotNull null
+                    val lat =
+                        entry.getOrNull(1)?.jsonPrimitive?.content?.toDoubleOrNull()
+                            ?: return@mapNotNull null
+                    val lon =
+                        entry.getOrNull(2)?.jsonPrimitive?.content?.toDoubleOrNull()
+                            ?: return@mapNotNull null
+                    val altBaro =
+                        when (val altEl = entry.getOrNull(3)) {
+                            null, JsonNull -> null
+                            else -> altEl.jsonPrimitive.content
+                        }
+                    AircraftPosition(
+                        latitude = lat,
+                        longitude = lon,
+                        altitude = altBaro,
+                        timestamp = response.timestamp + timeOffset,
+                    )
+                }
+            if (positions.isNotEmpty()) {
+                result[response.icao] = positions.toMutableList()
+            }
+        }
+        return result
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/api/impl/ReadsbDataSource.kt
@@ -3,6 +3,7 @@ package com.jordankurtz.piawaremobile.aircraft.api.impl
 import com.jordankurtz.logger.Logger
 import com.jordankurtz.piawaremobile.aircraft.api.AircraftDataSource
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
@@ -18,7 +19,6 @@ import org.koin.core.annotation.Single
 class ReadsbDataSource(
     private val httpClient: HttpClient,
 ) : AircraftDataSource {
-    override val supportsHistory: Boolean = false
 
     override suspend fun getAircraft(server: Server): List<Aircraft> {
         return try {
@@ -74,13 +74,10 @@ class ReadsbDataSource(
         }
     }
 
-    override suspend fun getHistory(
-        server: Server,
-        index: Int,
-    ): PiAwareResponse? {
+    override suspend fun fetchTrails(server: Server): Map<String, List<AircraftPosition>> {
         // readsb uses a trace API (/data/traces/) instead of history files.
         // Trace API support will be added in a follow-up issue.
-        Logger.d("History files not supported for readsb server ${server.address}, use trace API instead")
-        return null
+        Logger.d("fetchTrails not yet supported for readsb server ${server.address}, use trace API instead")
+        return emptyMap()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImpl.kt
@@ -8,7 +8,6 @@ import com.jordankurtz.piawaremobile.model.AircraftInfo
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.model.FlightResponse
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.model.ReceiverType
 import com.jordankurtz.piawaremobile.settings.Server
@@ -16,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -126,39 +124,9 @@ class AircraftRepoImpl(
 
     override suspend fun fetchAndMergeHistory(server: Server) {
         val dataSource = dataSourceFactory.getDataSource(server.type)
-        if (!dataSource.supportsHistory) return
-        val receiver = dataSource.getReceiverInfo(server) ?: return
-        val historyCount = receiver.history ?: return
-        if (historyCount <= 0) return
-
-        coroutineScope {
-            val historyResults =
-                (0 until historyCount).map { index ->
-                    async {
-                        fetchHistoryWithRetry(server, index)
-                    }
-                }.awaitAll()
-
-            trailManager.mergeHistoryResponses(historyResults.filterNotNull())
-        }
-    }
-
-    private suspend fun fetchHistoryWithRetry(
-        server: Server,
-        index: Int,
-        maxRetries: Int = 3,
-    ): PiAwareResponse? {
-        val dataSource = dataSourceFactory.getDataSource(server.type)
-        repeat(maxRetries) { attempt ->
-            val result = dataSource.getHistory(server, index)
-            if (result != null) return result
-
-            if (attempt < maxRetries - 1) {
-                val delayMs = (attempt + 1) * 500L
-                delay(delayMs)
-            }
-        }
-        return null
+        val trails = dataSource.fetchTrails(server)
+        if (trails.isEmpty()) return
+        trailManager.mergeTrails(trails)
     }
 
     internal suspend fun lookupAircraftInfoRecursive(

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManager.kt
@@ -3,15 +3,12 @@ package com.jordankurtz.piawaremobile.aircraft.repo
 import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.AircraftTrail
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import kotlinx.coroutines.flow.StateFlow
 
 interface AircraftTrailManager {
     val aircraftTrails: StateFlow<Map<String, AircraftTrail>>
 
     suspend fun updateTrailsFromAircraft(aircraft: List<Aircraft>)
-
-    suspend fun mergeHistoryResponses(responses: List<PiAwareResponse>)
 
     suspend fun mergeTrails(trails: Map<String, List<AircraftPosition>>)
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManager.kt
@@ -1,6 +1,7 @@
 package com.jordankurtz.piawaremobile.aircraft.repo
 
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.AircraftTrail
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import kotlinx.coroutines.flow.StateFlow
@@ -11,6 +12,8 @@ interface AircraftTrailManager {
     suspend fun updateTrailsFromAircraft(aircraft: List<Aircraft>)
 
     suspend fun mergeHistoryResponses(responses: List<PiAwareResponse>)
+
+    suspend fun mergeTrails(trails: Map<String, List<AircraftPosition>>)
 
     suspend fun clearTrails()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
@@ -55,8 +55,9 @@ class AircraftTrailManagerImpl : AircraftTrailManager {
                 positions.addAll(newPositions)
             }
 
-            // Sort positions by timestamp and deduplicate
-            trailPositions.forEach { (_, positions) ->
+            // Sort positions by timestamp and deduplicate only the updated entries
+            trails.keys.forEach { hex ->
+                val positions = trailPositions[hex] ?: return@forEach
                 val sorted = positions.sortedBy { it.timestamp }.distinctBy { it.timestamp }
                 positions.clear()
                 sorted.forEach { pos ->

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
@@ -3,7 +3,6 @@ package com.jordankurtz.piawaremobile.aircraft.repo
 import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.AircraftTrail
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -44,42 +43,6 @@ class AircraftTrailManagerImpl : AircraftTrailManager {
                         positions.add(newPosition)
                     }
                 }
-
-            updateTrailsStateFlow()
-        }
-    }
-
-    override suspend fun mergeHistoryResponses(responses: List<PiAwareResponse>) {
-        trailMutex.withLock {
-            responses.forEach { response ->
-                val snapshotTime = response.now ?: return@forEach
-                response.aircraft
-                    .filter { it.hasPosition }
-                    .forEach { aircraft ->
-                        val positions = trailPositions.getOrPut(aircraft.hex) { mutableListOf() }
-                        val positionAge = aircraft.seenPos ?: aircraft.seen ?: 0f
-                        val newPosition =
-                            AircraftPosition(
-                                latitude = aircraft.lat,
-                                longitude = aircraft.lon,
-                                altitude = aircraft.altBaro,
-                                timestamp = snapshotTime - positionAge,
-                            )
-                        positions.add(newPosition)
-                    }
-            }
-
-            // Sort positions by timestamp and deduplicate
-            trailPositions.forEach { (_, positions) ->
-                val sorted = positions.sortedBy { it.timestamp }.distinctBy { it.timestamp }
-                positions.clear()
-                sorted.forEach { pos ->
-                    val last = positions.lastOrNull()
-                    if (last == null || last.latitude != pos.latitude || last.longitude != pos.longitude) {
-                        positions.add(pos)
-                    }
-                }
-            }
 
             updateTrailsStateFlow()
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImpl.kt
@@ -85,6 +85,29 @@ class AircraftTrailManagerImpl : AircraftTrailManager {
         }
     }
 
+    override suspend fun mergeTrails(trails: Map<String, List<AircraftPosition>>) {
+        trailMutex.withLock {
+            trails.forEach { (hex, newPositions) ->
+                val positions = trailPositions.getOrPut(hex) { mutableListOf() }
+                positions.addAll(newPositions)
+            }
+
+            // Sort positions by timestamp and deduplicate
+            trailPositions.forEach { (_, positions) ->
+                val sorted = positions.sortedBy { it.timestamp }.distinctBy { it.timestamp }
+                positions.clear()
+                sorted.forEach { pos ->
+                    val last = positions.lastOrNull()
+                    if (last == null || last.latitude != pos.latitude || last.longitude != pos.longitude) {
+                        positions.add(pos)
+                    }
+                }
+            }
+
+            updateTrailsStateFlow()
+        }
+    }
+
     override suspend fun clearTrails() {
         trailMutex.withLock {
             trailPositions.clear()

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/ReadsbTraceResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/ReadsbTraceResponse.kt
@@ -1,11 +1,46 @@
 package com.jordankurtz.piawaremobile.model
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
 data class ReadsbTraceResponse(
     val icao: String,
     val timestamp: Double,
-    val trace: List<JsonArray>,
+    val trace: List<TraceEntry>,
 )
+
+@Serializable(with = TraceEntrySerializer::class)
+data class TraceEntry(
+    val timeOffset: Double,
+    val latitude: Double,
+    val longitude: Double,
+    val altitude: String?,
+)
+
+internal object TraceEntrySerializer : KSerializer<TraceEntry> {
+    override val descriptor: SerialDescriptor = JsonArray.serializer().descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: TraceEntry,
+    ) = throw UnsupportedOperationException()
+
+    override fun deserialize(decoder: Decoder): TraceEntry {
+        val array = (decoder as JsonDecoder).decodeJsonElement().jsonArray
+        return TraceEntry(
+            timeOffset = array[0].jsonPrimitive.content.toDouble(),
+            latitude = array[1].jsonPrimitive.content.toDouble(),
+            longitude = array[2].jsonPrimitive.content.toDouble(),
+            altitude = array.getOrNull(3)?.takeIf { it != JsonNull }?.jsonPrimitive?.content,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/ReadsbTraceResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/model/ReadsbTraceResponse.kt
@@ -1,0 +1,11 @@
+package com.jordankurtz.piawaremobile.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+
+@Serializable
+data class ReadsbTraceResponse(
+    val icao: String,
+    val timestamp: Double,
+    val trace: List<JsonArray>,
+)

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareDataSourceTest.kt
@@ -2,10 +2,12 @@ package com.jordankurtz.piawaremobile.aircraft.api
 
 import com.jordankurtz.piawaremobile.aircraft.api.impl.PiAwareDataSource
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.settings.Server
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
@@ -79,11 +81,6 @@ class PiAwareDataSourceTest {
         }
 
     @Test
-    fun `supportsHistory returns true`() {
-        assertTrue(dataSource.supportsHistory)
-    }
-
-    @Test
     fun `getAircraftTypes delegates to PiAwareApi`() =
         runTest {
             val expected = mapOf("A320" to ICAOAircraftType("Airbus A320", "L2J"))
@@ -106,13 +103,84 @@ class PiAwareDataSourceTest {
         }
 
     @Test
-    fun `getHistory delegates to PiAwareApi getHistoryFile`() =
+    fun `fetchTrails returns empty map when receiver is null`() =
         runTest {
-            val expected = PiAwareResponse(now = 1000.0, aircraft = emptyList())
-            everySuspend { piAwareApi.getHistoryFile("test-host", 0) } returns expected
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns null
 
-            val result = dataSource.getHistory(server, 0)
+            val result = dataSource.fetchTrails(server)
 
-            assertEquals(expected, result)
+            assertEquals(emptyMap(), result)
+        }
+
+    @Test
+    fun `fetchTrails returns empty map when history count is null`() =
+        runTest {
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns
+                Receiver(latitude = 32.7f, longitude = -96.8f, history = null)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(emptyMap(), result)
+        }
+
+    @Test
+    fun `fetchTrails returns empty map when history count is zero`() =
+        runTest {
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns
+                Receiver(latitude = 32.7f, longitude = -96.8f, history = 0)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(emptyMap(), result)
+        }
+
+    @Test
+    fun `fetchTrails converts history responses to positions keyed by hex`() =
+        runTest {
+            val aircraft = Aircraft(hex = "abc123", lat = 32.7, lon = -96.8, seenPos = 2f)
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns
+                Receiver(latitude = 32.7f, longitude = -96.8f, history = 1)
+            everySuspend { piAwareApi.getHistoryFile("test-host", 0) } returns
+                PiAwareResponse(now = 1000.0, aircraft = listOf(aircraft))
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(1, result.size)
+            val positions = result["abc123"]!!
+            assertEquals(1, positions.size)
+            assertEquals(32.7, positions[0].latitude)
+            assertEquals(-96.8, positions[0].longitude)
+            assertEquals(998.0, positions[0].timestamp) // now - seenPos = 1000 - 2
+        }
+
+    @Test
+    fun `fetchTrails retries failed history fetches up to 3 times`() =
+        runTest {
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns
+                Receiver(latitude = 32.7f, longitude = -96.8f, history = 1)
+            var callCount = 0
+            everySuspend { piAwareApi.getHistoryFile("test-host", 0) } calls { _ ->
+                callCount++
+                if (callCount < 3) null else PiAwareResponse(now = 1000.0, aircraft = emptyList())
+            }
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(3, callCount)
+            assertEquals(emptyMap(), result)
+        }
+
+    @Test
+    fun `fetchTrails skips history responses with null timestamp`() =
+        runTest {
+            val aircraft = Aircraft(hex = "abc123", lat = 32.7, lon = -96.8)
+            everySuspend { piAwareApi.getDump1090ReceiverInfo("test-host") } returns
+                Receiver(latitude = 32.7f, longitude = -96.8f, history = 1)
+            everySuspend { piAwareApi.getHistoryFile("test-host", 0) } returns
+                PiAwareResponse(now = null, aircraft = listOf(aircraft))
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(emptyMap(), result)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/PiAwareDataSourceTest.kt
@@ -2,7 +2,6 @@ package com.jordankurtz.piawaremobile.aircraft.api
 
 import com.jordankurtz.piawaremobile.aircraft.api.impl.PiAwareDataSource
 import com.jordankurtz.piawaremobile.model.Aircraft
-import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
 import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
@@ -18,7 +17,6 @@ import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class PiAwareDataSourceTest {
     private val piAwareApi: PiAwareApi = mock()

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/ReadsbDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/ReadsbDataSourceTest.kt
@@ -21,7 +21,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -201,7 +200,7 @@ class ReadsbDataSourceTest {
         }
 
     @Test
-    fun `getHistory returns null for readsb servers`() =
+    fun `fetchTrails returns empty map for readsb servers`() =
         runTest {
             val mockEngine =
                 MockEngine {
@@ -209,19 +208,8 @@ class ReadsbDataSourceTest {
                 }
             val dataSource = createDataSource(mockEngine)
 
-            val result = dataSource.getHistory(server, 0)
+            val result = dataSource.fetchTrails(server)
 
-            assertNull(result)
+            assertEquals(emptyMap(), result)
         }
-
-    @Test
-    fun `supportsHistory returns false`() {
-        val mockEngine =
-            MockEngine {
-                error("Should not make any HTTP requests")
-            }
-        val dataSource = createDataSource(mockEngine)
-
-        assertFalse(dataSource.supportsHistory)
-    }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/ReadsbDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/api/ReadsbDataSourceTest.kt
@@ -200,16 +200,190 @@ class ReadsbDataSourceTest {
         }
 
     @Test
-    fun `fetchTrails returns empty map for readsb servers`() =
+    fun `fetchTrails fetches traces for all aircraft with position`() =
+        runTest {
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"abc123","timestamp":1000.0,"trace":[[5.0,32.7,-96.8,35000]]}"""
+
+            val mockEngine =
+                MockEngine { request ->
+                    when (request.url.toString()) {
+                        "http://readsb-host/data/aircraft.json" ->
+                            respond(
+                                content = aircraftJson,
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        "http://readsb-host/data/traces/ab/abc123.json" ->
+                            respond(
+                                content = traceJson,
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        else -> error("Unexpected URL: ${request.url}")
+                    }
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(1, result.size)
+            val positions = result["abc123"]!!
+            assertEquals(1, positions.size)
+            assertEquals(32.7, positions[0].latitude)
+            assertEquals(-96.8, positions[0].longitude)
+            assertEquals(1005.0, positions[0].timestamp) // 1000.0 + 5.0
+            assertEquals("35000", positions[0].altitude)
+        }
+
+    @Test
+    fun `fetchTrails constructs trace URL using two-char hex prefix`() =
+        runTest {
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"abc123","timestamp":1000.0,"trace":[]}"""
+
+            var traceUrl = ""
+            val mockEngine =
+                MockEngine { request ->
+                    if (request.url.toString().contains("traces")) {
+                        traceUrl = request.url.toString()
+                    }
+                    respond(
+                        content = if (request.url.toString().contains("aircraft")) aircraftJson else traceJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            dataSource.fetchTrails(server)
+
+            assertEquals("http://readsb-host/data/traces/ab/abc123.json", traceUrl)
+        }
+
+    @Test
+    fun `fetchTrails handles ground altitude in trace entry`() =
+        runTest {
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"abc123","timestamp":1000.0,"trace":[[0.0,32.7,-96.8,"ground"]]}"""
+
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = if (request.url.toString().contains("aircraft")) aircraftJson else traceJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals("ground", result["abc123"]?.first()?.altitude)
+        }
+
+    @Test
+    fun `fetchTrails handles null altitude in trace entry`() =
+        runTest {
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"abc123","timestamp":1000.0,"trace":[[0.0,32.7,-96.8,null]]}"""
+
+            val mockEngine =
+                MockEngine { request ->
+                    respond(
+                        content = if (request.url.toString().contains("aircraft")) aircraftJson else traceJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertNull(result["abc123"]?.first()?.altitude)
+        }
+
+    @Test
+    fun `fetchTrails skips aircraft without position`() =
+        runTest {
+            val aircraft =
+                listOf(
+                    // no position — hasPosition is false when lat == 0.0 && lon == 0.0
+                    Aircraft(hex = "abc123", lat = 0.0, lon = 0.0),
+                    Aircraft(hex = "def456", lat = 32.7, lon = -96.8),
+                )
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"def456","timestamp":1000.0,"trace":[]}"""
+
+            var requestCount = 0
+            val mockEngine =
+                MockEngine { request ->
+                    if (request.url.toString().contains("traces")) requestCount++
+                    respond(
+                        content = if (request.url.toString().contains("aircraft")) aircraftJson else traceJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            dataSource.fetchTrails(server)
+
+            assertEquals(1, requestCount) // only def456 fetched, not abc123
+        }
+
+    @Test
+    fun `fetchTrails returns empty map when aircraft fetch fails`() =
         runTest {
             val mockEngine =
                 MockEngine {
-                    error("Should not make any HTTP requests")
+                    respond(content = "Error", status = HttpStatusCode.InternalServerError)
                 }
             val dataSource = createDataSource(mockEngine)
 
             val result = dataSource.fetchTrails(server)
 
             assertEquals(emptyMap(), result)
+        }
+
+    @Test
+    fun `fetchTrails skips failed trace fetches and returns successful ones`() =
+        runTest {
+            val aircraft =
+                listOf(
+                    Aircraft(hex = "abc123", lat = 32.7, lon = -96.8),
+                    Aircraft(hex = "def456", lat = 33.0, lon = -97.0),
+                )
+            val aircraftJson = Json.encodeToString(PiAwareResponse(aircraft = aircraft))
+            val traceJson = """{"icao":"abc123","timestamp":1000.0,"trace":[[0.0,32.7,-96.8,35000]]}"""
+
+            val mockEngine =
+                MockEngine { request ->
+                    when {
+                        request.url.toString().contains("aircraft") ->
+                            respond(
+                                content = aircraftJson,
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        request.url.toString().contains("abc123") ->
+                            respond(
+                                content = traceJson,
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        else -> respond(content = "Error", status = HttpStatusCode.InternalServerError)
+                    }
+                }
+            val dataSource = createDataSource(mockEngine)
+
+            val result = dataSource.fetchTrails(server)
+
+            assertEquals(1, result.size)
+            assertNotNull(result["abc123"])
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
@@ -4,17 +4,16 @@ import com.jordankurtz.piawaremobile.aircraft.api.AeroApi
 import com.jordankurtz.piawaremobile.aircraft.api.AircraftDataSource
 import com.jordankurtz.piawaremobile.aircraft.api.AircraftDataSourceFactory
 import com.jordankurtz.piawaremobile.model.Aircraft
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.model.FlightResponse
 import com.jordankurtz.piawaremobile.model.ICAOAircraftType
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
 import com.jordankurtz.piawaremobile.model.Receiver
 import com.jordankurtz.piawaremobile.model.ReceiverType
 import com.jordankurtz.piawaremobile.settings.Server
 import com.jordankurtz.piawaremobile.settings.ServerType
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
-import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -59,9 +58,8 @@ class AircraftRepoImplTest {
         dataSourceFactory = mock()
         aeroApi = mock()
         trailManager = mock()
-        every { dataSource.supportsHistory } returns true
         everySuspend { trailManager.updateTrailsFromAircraft(any()) } returns Unit
-        everySuspend { trailManager.mergeHistoryResponses(any()) } returns Unit
+        everySuspend { trailManager.mergeTrails(any()) } returns Unit
         everySuspend { dataSourceFactory.getDataSource(any()) } returns dataSource
         repo = AircraftRepoImpl(dataSourceFactory, aeroApi, trailManager)
     }
@@ -282,56 +280,31 @@ class AircraftRepoImplTest {
     @Test
     fun `fetchAndMergeHistory delegates to trail manager`() =
         runTest {
-            val historyReceiver = mockReceiver1090.copy(history = 2)
-            val historyAircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 5f)
-
-            everySuspend { dataSource.getReceiverInfo(server1) } returns historyReceiver
-            everySuspend { dataSource.getHistory(server1, 0) } returns
-                PiAwareResponse(now = 1000.0, aircraft = listOf(historyAircraft))
-            everySuspend { dataSource.getHistory(server1, 1) } returns
-                PiAwareResponse(now = 1030.0, aircraft = listOf(historyAircraft.copy(lat = 32.6, seenPos = 5f)))
+            val trails =
+                mapOf(
+                    "abc123" to
+                        listOf(
+                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 995.0),
+                        ),
+                )
+            everySuspend { dataSource.fetchTrails(server1) } returns trails
 
             repo.fetchAndMergeHistory(server1)
 
             verifySuspend(mode = VerifyMode.exactly(1)) {
-                trailManager.mergeHistoryResponses(any())
+                trailManager.mergeTrails(any())
             }
         }
 
     @Test
-    fun `fetchAndMergeHistory handles null receiver`() =
+    fun `fetchAndMergeHistory skips mergeTrails when fetchTrails returns empty`() =
         runTest {
-            everySuspend { dataSource.getReceiverInfo(server1) } returns null
+            everySuspend { dataSource.fetchTrails(server1) } returns emptyMap()
 
             repo.fetchAndMergeHistory(server1)
 
             verifySuspend(mode = VerifyMode.exactly(0)) {
-                trailManager.mergeHistoryResponses(any())
-            }
-        }
-
-    @Test
-    fun `fetchAndMergeHistory handles null history count`() =
-        runTest {
-            everySuspend { dataSource.getReceiverInfo(server1) } returns mockReceiver1090
-
-            repo.fetchAndMergeHistory(server1)
-
-            verifySuspend(mode = VerifyMode.exactly(0)) {
-                trailManager.mergeHistoryResponses(any())
-            }
-        }
-
-    @Test
-    fun `fetchAndMergeHistory handles zero history count`() =
-        runTest {
-            everySuspend { dataSource.getReceiverInfo(server1) } returns
-                mockReceiver1090.copy(history = 0)
-
-            repo.fetchAndMergeHistory(server1)
-
-            verifySuspend(mode = VerifyMode.exactly(0)) {
-                trailManager.mergeHistoryResponses(any())
+                trailManager.mergeTrails(any())
             }
         }
 
@@ -429,21 +402,4 @@ class AircraftRepoImplTest {
             verifySuspend { dataSourceFactory.getDataSource(ServerType.READSB) }
         }
 
-    @Test
-    fun `fetchAndMergeHistory skips entirely when supportsHistory is false`() =
-        runTest {
-            val readsbServer = Server(name = "Readsb", address = "readsb.local", type = ServerType.READSB)
-            val readsbDs: AircraftDataSource = mock()
-            every { readsbDs.supportsHistory } returns false
-            everySuspend { dataSourceFactory.getDataSource(ServerType.READSB) } returns readsbDs
-
-            repo.fetchAndMergeHistory(readsbServer)
-
-            verifySuspend(mode = VerifyMode.exactly(0)) {
-                readsbDs.getReceiverInfo(readsbServer)
-            }
-            verifySuspend(mode = VerifyMode.exactly(0)) {
-                trailManager.mergeHistoryResponses(any())
-            }
-        }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
@@ -401,5 +401,4 @@ class AircraftRepoImplTest {
             verifySuspend { dataSourceFactory.getDataSource(ServerType.PIAWARE) }
             verifySuspend { dataSourceFactory.getDataSource(ServerType.READSB) }
         }
-
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftRepoImplTest.kt
@@ -60,6 +60,7 @@ class AircraftRepoImplTest {
         trailManager = mock()
         everySuspend { trailManager.updateTrailsFromAircraft(any()) } returns Unit
         everySuspend { trailManager.mergeTrails(any()) } returns Unit
+        everySuspend { dataSource.fetchTrails(any()) } returns emptyMap()
         everySuspend { dataSourceFactory.getDataSource(any()) } returns dataSource
         repo = AircraftRepoImpl(dataSourceFactory, aeroApi, trailManager)
     }
@@ -278,34 +279,30 @@ class AircraftRepoImplTest {
         }
 
     @Test
-    fun `fetchAndMergeHistory delegates to trail manager`() =
+    fun `fetchAndMergeHistory delegates to trail manager with trails from data source`() =
         runTest {
             val trails =
                 mapOf(
                     "abc123" to
                         listOf(
-                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 995.0),
+                            AircraftPosition(latitude = 32.7, longitude = -96.8, altitude = null, timestamp = 1000.0),
                         ),
                 )
             everySuspend { dataSource.fetchTrails(server1) } returns trails
 
             repo.fetchAndMergeHistory(server1)
 
-            verifySuspend(mode = VerifyMode.exactly(1)) {
-                trailManager.mergeTrails(any())
-            }
+            verifySuspend(mode = VerifyMode.exactly(1)) { trailManager.mergeTrails(trails) }
         }
 
     @Test
-    fun `fetchAndMergeHistory skips mergeTrails when fetchTrails returns empty`() =
+    fun `fetchAndMergeHistory does not call trail manager when fetchTrails returns empty map`() =
         runTest {
             everySuspend { dataSource.fetchTrails(server1) } returns emptyMap()
 
             repo.fetchAndMergeHistory(server1)
 
-            verifySuspend(mode = VerifyMode.exactly(0)) {
-                trailManager.mergeTrails(any())
-            }
+            verifySuspend(mode = VerifyMode.exactly(0)) { trailManager.mergeTrails(any()) }
         }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImplTest.kt
@@ -1,7 +1,7 @@
 package com.jordankurtz.piawaremobile.aircraft.repo
 
 import com.jordankurtz.piawaremobile.model.Aircraft
-import com.jordankurtz.piawaremobile.model.PiAwareResponse
+import com.jordankurtz.piawaremobile.model.AircraftPosition
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -88,82 +88,6 @@ class AircraftTrailManagerImplTest {
         }
 
     @Test
-    fun `mergeHistoryResponses builds trails from history`() =
-        runTest {
-            val historyAircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 5f)
-            val responses =
-                listOf(
-                    PiAwareResponse(
-                        now = 1000.0,
-                        aircraft = listOf(historyAircraft),
-                    ),
-                    PiAwareResponse(
-                        now = 1030.0,
-                        aircraft = listOf(historyAircraft.copy(lat = 32.6, seenPos = 5f)),
-                    ),
-                )
-
-            trailManager.mergeHistoryResponses(responses)
-
-            // History positions are stored but not emitted until aircraft becomes current
-            trailManager.updateTrailsFromAircraft(listOf(historyAircraft))
-
-            val trails = trailManager.aircraftTrails.value
-            assertTrue(trails.containsKey(historyAircraft.hex))
-            assertTrue(trails[historyAircraft.hex]!!.positions.size >= 2)
-        }
-
-    @Test
-    fun `mergeHistoryResponses deduplicates positions on repeated calls`() =
-        runTest {
-            val historyAircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 5f)
-            val responses =
-                listOf(
-                    PiAwareResponse(
-                        now = 1000.0,
-                        aircraft = listOf(historyAircraft),
-                    ),
-                    PiAwareResponse(
-                        now = 1030.0,
-                        aircraft = listOf(historyAircraft.copy(lat = 32.6, seenPos = 5f)),
-                    ),
-                )
-
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.mergeHistoryResponses(responses) // Same data again
-
-            trailManager.updateTrailsFromAircraft(listOf(historyAircraft))
-
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[historyAircraft.hex]!!.positions
-            // 2 deduped history positions + 1 current = 3
-            assertEquals(3, positions.size)
-        }
-
-    @Test
-    fun `mergeHistoryResponses sorts positions by timestamp`() =
-        runTest {
-            val historyAircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 0f)
-            val responses =
-                listOf(
-                    PiAwareResponse(now = 1060.0, aircraft = listOf(historyAircraft.copy(lat = 32.6))),
-                    PiAwareResponse(now = 1000.0, aircraft = listOf(historyAircraft.copy(lat = 32.5))),
-                    PiAwareResponse(now = 1120.0, aircraft = listOf(historyAircraft.copy(lat = 32.7))),
-                )
-
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.updateTrailsFromAircraft(listOf(historyAircraft.copy(lat = 32.7)))
-
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[historyAircraft.hex]!!.positions
-
-            assertEquals(3, positions.size)
-            assertEquals(32.5, positions[0].latitude)
-            assertEquals(32.6, positions[1].latitude)
-            assertEquals(32.7, positions[2].latitude)
-        }
-
-    @Test
     fun `updateTrailsFromAircraft with empty list clears current aircraft`() =
         runTest {
             trailManager.updateTrailsFromAircraft(listOf(aircraft1))
@@ -174,86 +98,100 @@ class AircraftTrailManagerImplTest {
         }
 
     @Test
-    fun `mergeHistoryResponses with empty list does not crash`() =
+    fun `mergeTrails adds positions from input map`() =
         runTest {
-            trailManager.mergeHistoryResponses(emptyList())
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            trailManager.updateTrailsFromAircraft(aircraft)
 
-            val trails = trailManager.aircraftTrails.value
-            assertTrue(trails.isEmpty())
+            trailManager.mergeTrails(
+                mapOf(
+                    "abc123" to listOf(
+                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = "35000", timestamp = 200.0),
+                    ),
+                ),
+            )
+
+            val trail = trailManager.aircraftTrails.value["abc123"]!!
+            assertTrue(trail.positions.any { it.timestamp == 100.0 })
+            assertTrue(trail.positions.any { it.timestamp == 200.0 })
         }
 
     @Test
-    fun `mergeHistoryResponses uses seenPos for position age`() =
+    fun `mergeTrails deduplicates positions with identical timestamps`() =
         runTest {
-            val aircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 10f, seen = 20f)
-            val responses =
-                listOf(
-                    PiAwareResponse(now = 1000.0, aircraft = listOf(aircraft)),
-                )
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            trailManager.updateTrailsFromAircraft(aircraft)
 
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.updateTrailsFromAircraft(listOf(aircraft))
+            val position = AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0)
+            trailManager.mergeTrails(mapOf("abc123" to listOf(position)))
+            trailManager.mergeTrails(mapOf("abc123" to listOf(position)))
 
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[aircraft.hex]!!.positions
-            // History position timestamp should be now - seenPos = 1000 - 10 = 990
-            assertEquals(990.0, positions.first().timestamp)
+            val trail = trailManager.aircraftTrails.value["abc123"]!!
+            assertEquals(1, trail.positions.count { it.timestamp == 100.0 })
         }
 
     @Test
-    fun `mergeHistoryResponses falls back to seen when seenPos is null`() =
+    fun `mergeTrails sorts positions by timestamp`() =
         runTest {
-            val aircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = null, seen = 15f)
-            val responses =
-                listOf(
-                    PiAwareResponse(now = 1000.0, aircraft = listOf(aircraft)),
-                )
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            trailManager.updateTrailsFromAircraft(aircraft)
 
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.updateTrailsFromAircraft(listOf(aircraft))
+            trailManager.mergeTrails(
+                mapOf(
+                    "abc123" to listOf(
+                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 200.0),
+                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                    ),
+                ),
+            )
 
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[aircraft.hex]!!.positions
-            // History position timestamp should be now - seen = 1000 - 15 = 985
-            assertEquals(985.0, positions.first().timestamp)
+            val positions = trailManager.aircraftTrails.value["abc123"]!!.positions
+            assertTrue(positions[0].timestamp < positions[1].timestamp)
         }
 
     @Test
-    fun `mergeHistoryResponses deduplicates by location after sort`() =
+    fun `mergeTrails deduplicates consecutive identical locations`() =
         runTest {
-            val aircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 0f)
-            val responses =
-                listOf(
-                    PiAwareResponse(now = 1000.0, aircraft = listOf(aircraft)),
-                    // Same location, different timestamp
-                    PiAwareResponse(now = 1030.0, aircraft = listOf(aircraft)),
-                )
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            trailManager.updateTrailsFromAircraft(aircraft)
 
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.updateTrailsFromAircraft(listOf(aircraft))
+            trailManager.mergeTrails(
+                mapOf(
+                    "abc123" to listOf(
+                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 200.0),
+                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 300.0),
+                    ),
+                ),
+            )
 
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[aircraft.hex]!!.positions
-            // Should deduplicate same lat/lon even with different timestamps
-            assertEquals(1, positions.size)
+            val positions = trailManager.aircraftTrails.value["abc123"]!!.positions
+            // 32.5/-96.5 appears twice in input; consecutive same-location dedup removes one.
+            // Plus the current position (32.7/-96.8) added by updateTrailsFromAircraft = 3 total.
+            assertEquals(3, positions.size)
         }
 
     @Test
-    fun `mergeHistoryResponses skips responses with null timestamp`() =
+    fun `mergeTrails with empty map does not crash`() =
         runTest {
-            val historyAircraft = Aircraft(hex = "abc123", lat = 32.5, lon = -96.5, seenPos = 0f)
-            val responses =
-                listOf(
-                    PiAwareResponse(now = null, aircraft = listOf(historyAircraft)),
-                    PiAwareResponse(now = 1000.0, aircraft = listOf(historyAircraft)),
-                )
+            trailManager.mergeTrails(emptyMap())
+        }
 
-            trailManager.mergeHistoryResponses(responses)
-            trailManager.updateTrailsFromAircraft(listOf(historyAircraft))
+    @Test
+    fun `mergeTrails accumulates across multiple calls`() =
+        runTest {
+            val aircraft = listOf(Aircraft(hex = "abc123", lat = 32.7, lon = -96.8))
+            trailManager.updateTrailsFromAircraft(aircraft)
 
-            val trails = trailManager.aircraftTrails.value
-            val positions = trails[historyAircraft.hex]!!.positions
-            // Only 1 from history (null timestamp skipped), current position deduped (same lat/lon)
-            assertEquals(1, positions.size)
+            trailManager.mergeTrails(
+                mapOf("abc123" to listOf(AircraftPosition(32.5, -96.5, null, 100.0))),
+            )
+            trailManager.mergeTrails(
+                mapOf("abc123" to listOf(AircraftPosition(32.6, -96.6, null, 200.0))),
+            )
+
+            val trail = trailManager.aircraftTrails.value["abc123"]!!
+            assertTrue(trail.positions.size >= 2)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/aircraft/repo/AircraftTrailManagerImplTest.kt
@@ -105,10 +105,11 @@ class AircraftTrailManagerImplTest {
 
             trailManager.mergeTrails(
                 mapOf(
-                    "abc123" to listOf(
-                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
-                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = "35000", timestamp = 200.0),
-                    ),
+                    "abc123" to
+                        listOf(
+                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                            AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = "35000", timestamp = 200.0),
+                        ),
                 ),
             )
 
@@ -139,10 +140,11 @@ class AircraftTrailManagerImplTest {
 
             trailManager.mergeTrails(
                 mapOf(
-                    "abc123" to listOf(
-                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 200.0),
-                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
-                    ),
+                    "abc123" to
+                        listOf(
+                            AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 200.0),
+                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                        ),
                 ),
             )
 
@@ -158,11 +160,12 @@ class AircraftTrailManagerImplTest {
 
             trailManager.mergeTrails(
                 mapOf(
-                    "abc123" to listOf(
-                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
-                        AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 200.0),
-                        AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 300.0),
-                    ),
+                    "abc123" to
+                        listOf(
+                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 100.0),
+                            AircraftPosition(latitude = 32.5, longitude = -96.5, altitude = null, timestamp = 200.0),
+                            AircraftPosition(latitude = 32.6, longitude = -96.6, altitude = null, timestamp = 300.0),
+                        ),
                 ),
             )
 


### PR DESCRIPTION
Closes #115

## Summary
- Add `ReadsbTraceResponse` model for the per-aircraft trace API (`/data/traces/{prefix}/{hex}.json`)
- Unify trail-fetching behind `AircraftDataSource.fetchTrails(server)` — each data source owns its fetch + conversion
- `PiAwareDataSource.fetchTrails` absorbs the history-file fetching and retry logic previously in `AircraftRepoImpl`
- `ReadsbDataSource.fetchTrails` fetches current aircraft, then fetches a trace per hex, converts `[time_offset, lat, lon, alt, ...]` entries to `AircraftPosition` using absolute timestamps
- `AircraftTrailManager.mergeTrails(Map<String, List<AircraftPosition>>)` replaces `mergeHistoryResponses` — trail manager is now source-agnostic
- `AircraftRepoImpl.fetchAndMergeHistory` reduced to two lines

## Test Plan
- [ ] `./gradlew :composeApp:testDebugUnitTest` passes
- [ ] `./gradlew :composeApp:desktopTest` passes
- [ ] `./gradlew ktlintCheck detekt` passes