### PR TITLE
Fix offlineMapsScreenRendersWithRegions instrumented test

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/OfflineMapsScreenAndroidTest.kt
@@ -3,6 +3,7 @@ package com.jordankurtz.piawaremobile
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.jordankurtz.piawaremobile.map.offline.DownloadStatus
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
 import com.jordankurtz.piawaremobile.settings.ui.OfflineMapsScreen
 import org.junit.Rule
@@ -41,6 +42,7 @@ class OfflineMapsScreenAndroidTest {
                     createdAt = 1700000000000L,
                     tileCount = 2400L,
                     sizeBytes = 50L * 1024 * 1024,
+                    status = DownloadStatus.COMPLETE,
                 ),
             )
         composeTestRule.setContent {


### PR DESCRIPTION
## Summary
- Fix `offlineMapsScreenRendersWithRegions` Android instrumented test that was asserting `'50 MB'` was displayed but always failing

## Root cause
The test was written before `DownloadStatus` was added to `OfflineRegion`. When `DownloadStatus` was introduced (in the offline maps download tracking feature), the field defaulted to `DOWNLOADING`. `OfflineMapsScreen` only renders the size text under `DownloadStatus.COMPLETE` — so the test's region was always rendering a progress indicator instead of `"50 MB"`.

The desktop counterpart (`OfflineMapsScreenTest.kt`) already sets `status = DownloadStatus.COMPLETE` correctly on all its regions.

## Fix
Added `status = DownloadStatus.COMPLETE` to the test region and the required `DownloadStatus` import.

## Test Plan
- [ ] `offlineMapsScreenRendersWithRegions` passes on device/emulator