### PR TITLE
Capture and display region map thumbnail (#151)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -100,7 +100,8 @@ kotlin {
             implementation(libs.datastore.preferences)
             implementation(libs.multiplatform.settings.datastore)
             implementation(libs.multiplatform.settings.coroutines)
-
+            implementation(libs.coil.compose)
+            implementation(compose.materialIconsExtended)
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -14,7 +14,7 @@ class MapRegionPickerScreenTest {
     @Test
     fun pickerRendersConfirmAndCancelButtons() {
         composeTestRule.setContent {
-            MapRegionPickerContent(onRegionSelected = {}, onDismiss = {}, mapLayer = {})
+            MapRegionPickerContent(onRegionSelected = { _, _ -> }, onDismiss = {}, mapLayer = {})
         }
         composeTestRule.onNodeWithText("Confirm", substring = true).assertIsDisplayed()
         composeTestRule.onNodeWithText("Cancel", substring = true).assertIsDisplayed()
@@ -23,7 +23,7 @@ class MapRegionPickerScreenTest {
     @Test
     fun modeToggleButtonRendersInDefaultBoxMode() {
         composeTestRule.setContent {
-            MapRegionPickerContent(onRegionSelected = {}, onDismiss = {}, mapLayer = {})
+            MapRegionPickerContent(onRegionSelected = { _, _ -> }, onDismiss = {}, mapLayer = {})
         }
         composeTestRule.onNodeWithContentDescription("Switch to map mode").assertIsDisplayed()
     }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -14,7 +14,7 @@ class DownloadRegionDialogTest {
     @Test
     fun downloadRegionDialogRendersElements() {
         composeTestRule.setContent {
-            DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _ -> })
+            DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _, _ -> })
         }
         composeTestRule.onNodeWithText("Download Region").assertIsDisplayed()
         composeTestRule.onNodeWithText("Region name").assertIsDisplayed()
@@ -25,7 +25,7 @@ class DownloadRegionDialogTest {
     @Test
     fun downloadButtonDisabledWhenNameBlank() {
         composeTestRule.setContent {
-            DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _ -> })
+            DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _, _ -> })
         }
         composeTestRule.onNodeWithText("Download").assertIsNotEnabled()
     }

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
@@ -35,10 +35,11 @@ actual class TileCacheModule {
     fun provideThumbnailGenerator(
         contextWrapper: ContextWrapper,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
-    ): ThumbnailGenerator = AndroidThumbnailGenerator(
-        tileCacheDir = File(contextWrapper.context.cacheDir, "map_tiles"),
-        ioDispatcher = ioDispatcher,
-    )
+    ): ThumbnailGenerator =
+        AndroidThumbnailGenerator(
+            tileCacheDir = File(contextWrapper.context.cacheDir, "map_tiles"),
+            ioDispatcher = ioDispatcher,
+        )
 
     @Single
     fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
@@ -32,7 +32,7 @@ actual class TileCacheModule {
     }
 
     @Single
-    fun provideThumbnailGenerator(
+    actual fun provideThumbnailGenerator(
         contextWrapper: ContextWrapper,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
     ): ThumbnailGenerator =
@@ -42,6 +42,6 @@ actual class TileCacheModule {
         )
 
     @Single
-    fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =
+    actual fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =
         AndroidThumbnailFileManager(File(contextWrapper.context.cacheDir, "thumbnails"))
 }

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.android.kt
@@ -5,6 +5,10 @@ import com.jordankurtz.piawaremobile.map.cache.FileTileCache
 import com.jordankurtz.piawaremobile.map.cache.JvmCacheFileSystem
 import com.jordankurtz.piawaremobile.map.cache.TileCache
 import com.jordankurtz.piawaremobile.map.cache.TileCacheDatabase
+import com.jordankurtz.piawaremobile.map.offline.AndroidThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.AndroidThumbnailGenerator
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailGenerator
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -26,4 +30,17 @@ actual class TileCacheModule {
             ioDispatcher = ioDispatcher,
         )
     }
+
+    @Single
+    fun provideThumbnailGenerator(
+        contextWrapper: ContextWrapper,
+        @IODispatcher ioDispatcher: CoroutineDispatcher,
+    ): ThumbnailGenerator = AndroidThumbnailGenerator(
+        tileCacheDir = File(contextWrapper.context.cacheDir, "map_tiles"),
+        ioDispatcher = ioDispatcher,
+    )
+
+    @Single
+    fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =
+        AndroidThumbnailFileManager(File(contextWrapper.context.cacheDir, "thumbnails"))
 }

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailFileManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailFileManager.kt
@@ -5,8 +5,7 @@ import java.io.File
 class AndroidThumbnailFileManager(
     private val thumbnailCacheDir: File,
 ) : ThumbnailFileManager {
-    override fun thumbnailPath(regionId: Long): String =
-        File(thumbnailCacheDir, "$regionId.png").absolutePath
+    override fun thumbnailPath(regionId: Long): String = File(thumbnailCacheDir, "$regionId.png").absolutePath
 
     override fun delete(regionId: Long) {
         File(thumbnailCacheDir, "$regionId.png").delete()

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailFileManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailFileManager.kt
@@ -1,0 +1,16 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import java.io.File
+
+class AndroidThumbnailFileManager(
+    private val thumbnailCacheDir: File,
+) : ThumbnailFileManager {
+    override fun thumbnailPath(regionId: Long): String =
+        File(thumbnailCacheDir, "$regionId.png").absolutePath
+
+    override fun delete(regionId: Long) {
+        File(thumbnailCacheDir, "$regionId.png").delete()
+    }
+
+    override fun exists(path: String): Boolean = File(path).exists()
+}

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailGenerator.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailGenerator.kt
@@ -1,0 +1,60 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+class AndroidThumbnailGenerator(
+    private val tileCacheDir: File,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ThumbnailGenerator {
+
+    override suspend fun generate(
+        bounds: BoundingBox,
+        providerId: String,
+        thumbnailZoom: Int,
+        outputPath: String,
+    ): Boolean = withContext(ioDispatcher) {
+        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+        val gridW = colMax - colMin + 1
+        val gridH = rowMax - rowMin + 1
+
+        val stitched = Bitmap.createBitmap(gridW * TILE_PX, gridH * TILE_PX, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(stitched)
+
+        for (col in colMin..colMax) {
+            for (row in rowMin..rowMax) {
+                val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
+                if (!tileFile.exists()) {
+                    stitched.recycle()
+                    return@withContext false
+                }
+                val tile = BitmapFactory.decodeFile(tileFile.absolutePath) ?: run {
+                    stitched.recycle()
+                    return@withContext false
+                }
+                canvas.drawBitmap(tile, ((col - colMin) * TILE_PX).toFloat(), ((row - rowMin) * TILE_PX).toFloat(), null)
+                tile.recycle()
+            }
+        }
+
+        val thumbnail = Bitmap.createScaledBitmap(stitched, OUTPUT_PX, OUTPUT_PX, true)
+        stitched.recycle()
+
+        File(outputPath).also { it.parentFile?.mkdirs() }.let { outFile ->
+            FileOutputStream(outFile).use { out -> thumbnail.compress(Bitmap.CompressFormat.PNG, 100, out) }
+        }
+        thumbnail.recycle()
+        true
+    }
+
+    private companion object {
+        const val TILE_PX = 256
+        const val OUTPUT_PX = 256
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailGenerator.kt
+++ b/composeApp/src/androidMain/kotlin/com/jordankurtz/piawaremobile/map/offline/AndroidThumbnailGenerator.kt
@@ -12,46 +12,52 @@ class AndroidThumbnailGenerator(
     private val tileCacheDir: File,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ThumbnailGenerator {
-
     override suspend fun generate(
         bounds: BoundingBox,
         providerId: String,
         thumbnailZoom: Int,
         outputPath: String,
-    ): Boolean = withContext(ioDispatcher) {
-        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
-        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
-        val gridW = colMax - colMin + 1
-        val gridH = rowMax - rowMin + 1
+    ): Boolean =
+        withContext(ioDispatcher) {
+            val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+            val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+            val gridW = colMax - colMin + 1
+            val gridH = rowMax - rowMin + 1
 
-        val stitched = Bitmap.createBitmap(gridW * TILE_PX, gridH * TILE_PX, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(stitched)
+            val stitched = Bitmap.createBitmap(gridW * TILE_PX, gridH * TILE_PX, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(stitched)
 
-        for (col in colMin..colMax) {
-            for (row in rowMin..rowMax) {
-                val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
-                if (!tileFile.exists()) {
-                    stitched.recycle()
-                    return@withContext false
+            for (col in colMin..colMax) {
+                for (row in rowMin..rowMax) {
+                    val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
+                    if (!tileFile.exists()) {
+                        stitched.recycle()
+                        return@withContext false
+                    }
+                    val tile =
+                        BitmapFactory.decodeFile(tileFile.absolutePath) ?: run {
+                            stitched.recycle()
+                            return@withContext false
+                        }
+                    canvas.drawBitmap(
+                        tile,
+                        ((col - colMin) * TILE_PX).toFloat(),
+                        ((row - rowMin) * TILE_PX).toFloat(),
+                        null,
+                    )
+                    tile.recycle()
                 }
-                val tile = BitmapFactory.decodeFile(tileFile.absolutePath) ?: run {
-                    stitched.recycle()
-                    return@withContext false
-                }
-                canvas.drawBitmap(tile, ((col - colMin) * TILE_PX).toFloat(), ((row - rowMin) * TILE_PX).toFloat(), null)
-                tile.recycle()
             }
-        }
 
-        val thumbnail = Bitmap.createScaledBitmap(stitched, OUTPUT_PX, OUTPUT_PX, true)
-        stitched.recycle()
+            val thumbnail = Bitmap.createScaledBitmap(stitched, OUTPUT_PX, OUTPUT_PX, true)
+            stitched.recycle()
 
-        File(outputPath).also { it.parentFile?.mkdirs() }.let { outFile ->
-            FileOutputStream(outFile).use { out -> thumbnail.compress(Bitmap.CompressFormat.PNG, 100, out) }
+            File(outputPath).also { it.parentFile?.mkdirs() }.let { outFile ->
+                FileOutputStream(outFile).use { out -> thumbnail.compress(Bitmap.CompressFormat.PNG, 100, out) }
+            }
+            thumbnail.recycle()
+            true
         }
-        thumbnail.recycle()
-        true
-    }
 
     private companion object {
         const val TILE_PX = 256

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -185,4 +185,6 @@
     <string name="offline_maps_delete_confirm_message">Delete "%1$s"? This will free approximately %2$d MB of storage.</string>
     <string name="offline_maps_delete_confirm_delete">Delete</string>
     <string name="offline_maps_delete_confirm_cancel">Cancel</string>
+    <string name="offline_map_thumbnail">Map thumbnail</string>
+    <string name="offline_map_thumbnail_placeholder">Map thumbnail placeholder</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.kt
@@ -3,6 +3,8 @@ package com.jordankurtz.piawaremobile.di.modules
 import com.jordankurtz.piawaremobile.di.annotations.IODispatcher
 import com.jordankurtz.piawaremobile.map.cache.TileCache
 import com.jordankurtz.piawaremobile.map.cache.TileCacheDatabase
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailGenerator
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -15,4 +17,13 @@ expect class TileCacheModule() {
         database: TileCacheDatabase,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
     ): TileCache
+
+    @Single
+    fun provideThumbnailGenerator(
+        contextWrapper: ContextWrapper,
+        @IODispatcher ioDispatcher: CoroutineDispatcher,
+    ): ThumbnailGenerator
+
+    @Single
+    fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
@@ -7,7 +7,9 @@ import kotlin.math.abs
 import kotlin.math.asin
 import kotlin.math.exp
 import kotlin.math.ln
+import kotlin.math.log2
 import kotlin.math.pow
+import kotlin.math.roundToInt
 import kotlin.math.sin
 
 const val MAX_LEVEL = 16
@@ -18,6 +20,9 @@ private const val X0 = -2.0037508342789248E7
 val mapSize = mapSizeAtLevel(MAX_LEVEL, tileSize = TILE_SIZE)
 
 const val GROUND_ALTITUDE = "ground"
+
+fun scaleToOsmZoom(scale: Float): Int =
+    (MAX_LEVEL + log2(scale.toDouble())).roundToInt().coerceIn(MIN_LEVEL, MAX_LEVEL)
 
 fun mapSizeAtLevel(
     wmtsLevel: Int,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
@@ -21,8 +21,7 @@ val mapSize = mapSizeAtLevel(MAX_LEVEL, tileSize = TILE_SIZE)
 
 const val GROUND_ALTITUDE = "ground"
 
-fun scaleToOsmZoom(scale: Float): Int =
-    (MAX_LEVEL + log2(scale.toDouble())).roundToInt().coerceIn(MIN_LEVEL, MAX_LEVEL)
+fun scaleToOsmZoom(scale: Float): Int = (MAX_LEVEL + log2(scale.toDouble())).roundToInt().coerceIn(MIN_LEVEL, MAX_LEVEL)
 
 fun mapSizeAtLevel(
     wmtsLevel: Int,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreen.kt
@@ -38,6 +38,7 @@ import com.jordankurtz.piawaremobile.map.MapViewModel
 import com.jordankurtz.piawaremobile.map.OpenStreetMap
 import com.jordankurtz.piawaremobile.map.invertProjection
 import com.jordankurtz.piawaremobile.map.mapSize
+import com.jordankurtz.piawaremobile.map.scaleToOsmZoom
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -66,7 +67,7 @@ private enum class InteractionMode {
 
 @Composable
 fun MapRegionPickerScreen(
-    onRegionSelected: (BoundingBox) -> Unit,
+    onRegionSelected: (BoundingBox, viewportZoom: Int) -> Unit,
     onDismiss: () -> Unit,
     mapViewModel: MapViewModel = koinViewModel(),
 ) {
@@ -90,7 +91,7 @@ fun MapRegionPickerScreen(
 
 @Composable
 internal fun MapRegionPickerContent(
-    onRegionSelected: (BoundingBox) -> Unit,
+    onRegionSelected: (BoundingBox, viewportZoom: Int) -> Unit,
     onDismiss: () -> Unit,
     mapLayer: @Composable () -> Unit,
     scrollX: Double = 0.0,
@@ -312,6 +313,7 @@ internal fun MapRegionPickerContent(
                                 minLon = leftLon,
                                 maxLon = rightLon,
                             ),
+                            scaleToOsmZoom(scale.toFloat()),
                         )
                     },
                     modifier = Modifier.weight(1f),

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModel.kt
@@ -24,6 +24,8 @@ class OfflineMapsViewModel(
     private val engine: DownloadEngine,
     private val tileCache: TileCache,
     private val downloadScopeHolder: DownloadScopeHolder,
+    private val thumbnailGenerator: ThumbnailGenerator,
+    private val thumbnailFileManager: ThumbnailFileManager,
     @param:IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val _regions = MutableStateFlow<List<OfflineRegion>>(emptyList())
@@ -41,6 +43,7 @@ class OfflineMapsViewModel(
         viewModelScope.launch(ioDispatcher) {
             store.resetStuckDownloads()
             _regions.value = store.getRegions()
+            regenerateMissingThumbnails(_regions.value)
         }
     }
 
@@ -76,6 +79,7 @@ class OfflineMapsViewModel(
                 tileCache.delete(zoom, col, row, region.providerId)
             }
             store.deleteRegion(region.id)
+            thumbnailFileManager.delete(region.id)
             _regions.value = store.getRegions()
         }
     }
@@ -85,6 +89,7 @@ class OfflineMapsViewModel(
         bounds: BoundingBox,
         minZoom: Int,
         maxZoom: Int,
+        viewportZoom: Int,
         provider: TileProviderConfig = TileProviders.OPENSTREETMAP,
     ) {
         if (!_isDownloading.compareAndSet(expect = false, update = true)) return
@@ -99,12 +104,26 @@ class OfflineMapsViewModel(
                 maxLon = bounds.maxLon,
                 providerId = provider.id,
                 createdAt = Clock.System.now().toEpochMilliseconds(),
+                thumbnailZoom = viewportZoom,
             )
         downloadJob =
             downloadScopeHolder.scope.launch {
                 val regionId = store.saveRegion(region)
                 // Show the region immediately in the list before tiles start downloading
                 _regions.value = _regions.value + region.copy(id = regionId, status = DownloadStatus.DOWNLOADING)
+
+                val outputPath = thumbnailFileManager.thumbnailPath(regionId)
+                val generated =
+                    thumbnailGenerator.generate(
+                        bounds = bounds,
+                        providerId = provider.id,
+                        thumbnailZoom = viewportZoom,
+                        outputPath = outputPath,
+                    )
+                if (generated) {
+                    store.updateThumbnail(regionId, viewportZoom, outputPath)
+                }
+
                 doDownload(regionId)
             }
     }
@@ -155,6 +174,7 @@ class OfflineMapsViewModel(
             }
             // Refresh from DB on completion to pick up final stats and COMPLETE status
             _regions.value = store.getRegions()
+            regenerateMissingThumbnails(_regions.value)
         } catch (e: CancellationException) {
             withContext(NonCancellable) {
                 store.updateRegionStats(regionId, lastTileCount, 0L)
@@ -171,5 +191,28 @@ class OfflineMapsViewModel(
             _downloadProgress.value = null
             downloadJob = null
         }
+    }
+
+    private suspend fun regenerateMissingThumbnails(regions: List<OfflineRegion>) {
+        regions
+            .filter { region ->
+                region.thumbnailZoom != null &&
+                    region.status == DownloadStatus.COMPLETE &&
+                    (region.thumbnailPath == null || !thumbnailFileManager.exists(region.thumbnailPath!!))
+            }
+            .forEach { region ->
+                val path = thumbnailFileManager.thumbnailPath(region.id)
+                val ok =
+                    thumbnailGenerator.generate(
+                        bounds = BoundingBox(region.minLat, region.maxLat, region.minLon, region.maxLon),
+                        providerId = region.providerId,
+                        thumbnailZoom = region.thumbnailZoom!!,
+                        outputPath = path,
+                    )
+                if (ok) {
+                    store.updateThumbnail(region.id, region.thumbnailZoom!!, path)
+                    _regions.value = store.getRegions()
+                }
+            }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineRegion.kt
@@ -15,4 +15,6 @@ data class OfflineRegion(
     val sizeBytes: Long = 0L,
     val status: DownloadStatus = DownloadStatus.DOWNLOADING,
     val downloadedTileCount: Long = 0L,
+    val thumbnailZoom: Int? = null,
+    val thumbnailPath: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineTileStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineTileStore.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.map.offline
 
+@Suppress("TooManyFunctions")
 interface OfflineTileStore {
     suspend fun saveRegion(region: OfflineRegion): Long
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineTileStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineTileStore.kt
@@ -43,4 +43,10 @@ interface OfflineTileStore {
     suspend fun getFreedBytesForRegion(id: Long): Long
 
     suspend fun resetStuckDownloads()
+
+    suspend fun updateThumbnail(
+        id: Long,
+        zoom: Int,
+        path: String,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
@@ -128,6 +128,14 @@ class SqlDelightOfflineTileStore(
         withContext(ioDispatcher) {
             queries.resetStuckDownloads()
         }
+
+    override suspend fun updateThumbnail(
+        id: Long,
+        zoom: Int,
+        path: String,
+    ) = withContext(ioDispatcher) {
+        queries.updateRegionThumbnail(thumbnailZoom = zoom.toLong(), thumbnailPath = path, id = id)
+    }
 }
 
 private fun Offline_region.toOfflineRegion() =

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStore.kt
@@ -23,6 +23,7 @@ class SqlDelightOfflineTileStore(
                     provider_id = region.providerId,
                     created_at = region.createdAt,
                     status = region.status.name,
+                    thumbnail_zoom = region.thumbnailZoom?.toLong(),
                 )
                 queries.lastInsertedRegionId().executeAsOne()
             }
@@ -145,4 +146,6 @@ private fun Offline_region.toOfflineRegion() =
         sizeBytes = size_bytes,
         status = DownloadStatus.entries.find { it.name == status } ?: DownloadStatus.FAILED,
         downloadedTileCount = downloaded_tile_count,
+        thumbnailZoom = thumbnail_zoom?.toInt(),
+        thumbnailPath = thumbnail_path,
     )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/ThumbnailFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/ThumbnailFileManager.kt
@@ -1,0 +1,12 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+interface ThumbnailFileManager {
+    /** Returns the absolute path where the thumbnail for [regionId] should be written. */
+    fun thumbnailPath(regionId: Long): String
+
+    /** Deletes the thumbnail file for [regionId] if it exists. */
+    fun delete(regionId: Long)
+
+    /** Returns true if the file at [path] exists on disk. */
+    fun exists(path: String): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/ThumbnailGenerator.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/ThumbnailGenerator.kt
@@ -1,0 +1,15 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+interface ThumbnailGenerator {
+    /**
+     * Stitches cached tiles covering [bounds] at [thumbnailZoom] and writes a 256×256px PNG
+     * to [outputPath]. Returns false if any required tile is absent from disk — the caller
+     * should treat false as a signal to show a placeholder and retry later.
+     */
+    suspend fun generate(
+        bounds: BoundingBox,
+        providerId: String,
+        thumbnailZoom: Int,
+        outputPath: String,
+    ): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialog.kt
@@ -65,8 +65,9 @@ fun DownloadRegionDialog(
     name: String,
     onNameChange: (String) -> Unit,
     onDismiss: () -> Unit,
-    onConfirm: (minZoom: Int, maxZoom: Int) -> Unit,
+    onConfirm: (minZoom: Int, maxZoom: Int, viewportZoom: Int) -> Unit,
     selectedBounds: BoundingBox? = null,
+    selectedViewportZoom: Int = 0,
     onSelectOnMap: () -> Unit = {},
 ) {
     var minZoom by remember { mutableFloatStateOf(DEFAULT_MIN_ZOOM) }
@@ -217,7 +218,7 @@ fun DownloadRegionDialog(
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     TextButton(
-                        onClick = { onConfirm(minZoom.toInt(), maxZoom.toInt()) },
+                        onClick = { onConfirm(minZoom.toInt(), maxZoom.toInt(), selectedViewportZoom) },
                         enabled = isValid,
                     ) {
                         Text(stringResource(Res.string.offline_maps_dialog_download))

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -62,7 +62,7 @@ fun OfflineMapsScreen(
     regions: List<OfflineRegion> = emptyList(),
     onDeleteRegion: (OfflineRegion) -> Unit = {},
     onRetry: (OfflineRegion) -> Unit = {},
-    onStartDownload: (name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int) -> Unit = { _, _, _, _ -> },
+    onStartDownload: (name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int, viewportZoom: Int) -> Unit = { _, _, _, _, _ -> },
     onCancelDownload: () -> Unit = {},
 ) {
     var showDownloadDialog by remember { mutableStateOf(false) }
@@ -70,11 +70,13 @@ fun OfflineMapsScreen(
     var pendingBounds by remember { mutableStateOf<BoundingBox?>(null) }
     // Hoisted so the name survives round-trips to the map picker
     var pendingName by remember { mutableStateOf("") }
+    var pendingViewportZoom by remember { mutableStateOf(0) }
 
     if (showMapPicker) {
         MapRegionPickerScreen(
-            onRegionSelected = { bounds ->
+            onRegionSelected = { bounds, viewportZoom ->
                 pendingBounds = bounds
+                pendingViewportZoom = viewportZoom
                 showMapPicker = false
                 showDownloadDialog = true
             },
@@ -95,16 +97,18 @@ fun OfflineMapsScreen(
                 pendingBounds = null
                 pendingName = ""
             },
-            onConfirm = { minZoom, maxZoom ->
+            onConfirm = { minZoom, maxZoom, viewportZoom ->
                 val bounds = pendingBounds
                 if (bounds != null) {
-                    onStartDownload(pendingName, bounds, minZoom, maxZoom)
+                    onStartDownload(pendingName, bounds, minZoom, maxZoom, viewportZoom)
                     showDownloadDialog = false
                     pendingBounds = null
                     pendingName = ""
+                    pendingViewportZoom = 0
                 }
             },
             selectedBounds = pendingBounds,
+            selectedViewportZoom = pendingViewportZoom,
             onSelectOnMap = {
                 showDownloadDialog = false
                 showMapPicker = true

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -4,11 +4,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -29,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.jordankurtz.piawaremobile.map.offline.BoundingBox
 import com.jordankurtz.piawaremobile.map.offline.DownloadStatus
 import com.jordankurtz.piawaremobile.map.offline.MapRegionPickerScreen
@@ -42,6 +48,8 @@ import piawaremobile.composeapp.generated.resources.ic_clear
 import piawaremobile.composeapp.generated.resources.ic_delete
 import piawaremobile.composeapp.generated.resources.ic_refresh
 import piawaremobile.composeapp.generated.resources.navigate_back
+import piawaremobile.composeapp.generated.resources.offline_map_thumbnail
+import piawaremobile.composeapp.generated.resources.offline_map_thumbnail_placeholder
 import piawaremobile.composeapp.generated.resources.offline_maps_add_region
 import piawaremobile.composeapp.generated.resources.offline_maps_cancel_download
 import piawaremobile.composeapp.generated.resources.offline_maps_empty_message
@@ -62,7 +70,13 @@ fun OfflineMapsScreen(
     regions: List<OfflineRegion> = emptyList(),
     onDeleteRegion: (OfflineRegion) -> Unit = {},
     onRetry: (OfflineRegion) -> Unit = {},
-    onStartDownload: (name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int, viewportZoom: Int) -> Unit = { _, _, _, _, _ -> },
+    onStartDownload: (
+        name: String,
+        bounds: BoundingBox,
+        minZoom: Int,
+        maxZoom: Int,
+        viewportZoom: Int,
+    ) -> Unit = { _, _, _, _, _ -> },
     onCancelDownload: () -> Unit = {},
 ) {
     var showDownloadDialog by remember { mutableStateOf(false) }
@@ -208,7 +222,7 @@ private fun OfflineRegionList(
 }
 
 @Composable
-private fun OfflineRegionItem(
+internal fun OfflineRegionItem(
     region: OfflineRegion,
     onDelete: () -> Unit,
     onRetry: () -> Unit,
@@ -222,6 +236,25 @@ private fun OfflineRegionItem(
                 .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (region.thumbnailPath != null) {
+            AsyncImage(
+                model = "file://${region.thumbnailPath}",
+                contentDescription = stringResource(Res.string.offline_map_thumbnail),
+                modifier = Modifier.size(64.dp),
+            )
+        } else {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.size(64.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Map,
+                    contentDescription = stringResource(Res.string.offline_map_thumbnail_placeholder),
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = region.name,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -240,12 +242,12 @@ internal fun OfflineRegionItem(
             AsyncImage(
                 model = "file://${region.thumbnailPath}",
                 contentDescription = stringResource(Res.string.offline_map_thumbnail),
-                modifier = Modifier.size(64.dp),
+                modifier = Modifier.size(64.dp).clip(RoundedCornerShape(8.dp)),
             )
         } else {
             Box(
                 contentAlignment = Alignment.Center,
-                modifier = Modifier.size(64.dp),
+                modifier = Modifier.size(64.dp).clip(RoundedCornerShape(8.dp)),
             ) {
                 Icon(
                     imageVector = Icons.Outlined.Map,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
@@ -55,7 +55,7 @@ fun SettingsScreen() {
                     val onRetryDownload = remember(vm) { { region: OfflineRegion -> vm.retryDownload(region) } }
                     val onStartDownloadFn =
                         remember(vm) {
-                            { name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int ->
+                            { name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int, viewportZoom: Int ->
                                 vm.startDownload(name, bounds, minZoom, maxZoom)
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
@@ -56,7 +56,7 @@ fun SettingsScreen() {
                     val onStartDownloadFn =
                         remember(vm) {
                             { name: String, bounds: BoundingBox, minZoom: Int, maxZoom: Int, viewportZoom: Int ->
-                                vm.startDownload(name, bounds, minZoom, maxZoom)
+                                vm.startDownload(name, bounds, minZoom, maxZoom, viewportZoom)
                             }
                         }
                     pendingDelete?.let { region ->

--- a/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/4.sqm
+++ b/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/4.sqm
@@ -1,0 +1,3 @@
+-- Migration 3 → 4: add thumbnail fields to offline_region
+ALTER TABLE offline_region ADD COLUMN thumbnail_zoom INTEGER;
+ALTER TABLE offline_region ADD COLUMN thumbnail_path TEXT;

--- a/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/TileCache.sq
+++ b/composeApp/src/commonMain/sqldelight/com/jordankurtz/piawaremobile/map/cache/TileCache.sq
@@ -35,7 +35,9 @@ CREATE TABLE offline_region (
     tile_count            INTEGER NOT NULL DEFAULT 0,
     size_bytes            INTEGER NOT NULL DEFAULT 0,
     status                TEXT NOT NULL DEFAULT 'COMPLETE',
-    downloaded_tile_count INTEGER NOT NULL DEFAULT 0
+    downloaded_tile_count INTEGER NOT NULL DEFAULT 0,
+    thumbnail_zoom        INTEGER,
+    thumbnail_path        TEXT
 );
 
 CREATE TABLE pinned_tile (
@@ -109,8 +111,8 @@ DELETE FROM tile WHERE zoom_level = ? AND col = ? AND row = ? AND provider_id = 
 
 -- Offline region queries
 insertOfflineRegion:
-INSERT INTO offline_region (name, min_zoom, max_zoom, min_lat, max_lat, min_lon, max_lon, provider_id, created_at, status)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO offline_region (name, min_zoom, max_zoom, min_lat, max_lat, min_lon, max_lon, provider_id, created_at, status, thumbnail_zoom)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 lastInsertedRegionId:
 SELECT last_insert_rowid();
@@ -129,6 +131,11 @@ UPDATE offline_region SET tile_count = ?, size_bytes = ? WHERE id = ?;
 
 updateRegionStatus:
 UPDATE offline_region SET status = ?, downloaded_tile_count = ? WHERE id = ?;
+
+updateRegionThumbnail:
+UPDATE offline_region
+SET thumbnail_zoom = :thumbnailZoom, thumbnail_path = :thumbnailPath
+WHERE id = :id;
 
 -- Pinned tile queries
 insertPinnedTile:

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModelTest.kt
@@ -7,6 +7,7 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.matching
 import dev.mokkery.mock
+import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +37,8 @@ class OfflineMapsViewModelTest {
     private lateinit var store: OfflineTileStore
     private lateinit var engine: DownloadEngine
     private lateinit var tileCache: TileCache
+    private lateinit var thumbnailGenerator: ThumbnailGenerator
+    private lateinit var thumbnailFileManager: ThumbnailFileManager
     private lateinit var vm: OfflineMapsViewModel
 
     private val savedRegion =
@@ -53,12 +56,25 @@ class OfflineMapsViewModelTest {
             status = DownloadStatus.COMPLETE,
         )
 
+    private fun makeVm() =
+        OfflineMapsViewModel(
+            store,
+            engine,
+            tileCache,
+            downloadScopeHolder,
+            thumbnailGenerator,
+            thumbnailFileManager,
+            testDispatcher,
+        )
+
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         store = mock()
         engine = mock()
         tileCache = mock()
+        thumbnailGenerator = mock()
+        thumbnailFileManager = mock()
         everySuspend { store.resetStuckDownloads() } returns Unit
         everySuspend { store.updateDownloadStatus(any(), any(), any()) } returns Unit
         everySuspend { store.updateRegionStats(any(), any(), any()) } returns Unit
@@ -74,7 +90,7 @@ class OfflineMapsViewModelTest {
         runTest {
             everySuspend { store.getRegions() } returns listOf(savedRegion)
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             assertEquals(listOf(savedRegion), vm.regions.value)
@@ -87,8 +103,9 @@ class OfflineMapsViewModelTest {
             everySuspend { store.deleteRegion(any()) } returns Unit
             everySuspend { store.getExclusiveTilesForRegion(any()) } returns emptyList()
             everySuspend { store.getFreedBytesForRegion(any()) } returns 0L
+            every { thumbnailFileManager.delete(any()) } returns Unit
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             everySuspend { store.getRegions() } returns emptyList()
@@ -108,13 +125,15 @@ class OfflineMapsViewModelTest {
 
             everySuspend { store.getRegions() } returns emptyList()
             everySuspend { store.saveRegion(any()) } returns 2L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/2.png"
             every { engine.download(any(), any()) } returns flowOf(progress1, progress2)
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             val bounds = BoundingBox(minLat = 40.0, maxLat = 41.0, minLon = -75.0, maxLon = -74.0)
-            vm.startDownload("Airport area", bounds, minZoom = 8, maxZoom = 12)
+            vm.startDownload("Airport area", bounds, minZoom = 8, maxZoom = 12, viewportZoom = 10)
 
             assertTrue(vm.isDownloading.value)
 
@@ -128,31 +147,34 @@ class OfflineMapsViewModelTest {
         runTest(testDispatcher) {
             everySuspend { store.getRegions() } returns emptyList()
             everySuspend { store.saveRegion(any()) } returns 1L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/1.png"
             val progress = DownloadProgress(regionId = 1L, downloaded = 5L, total = 10L)
             every { engine.download(any(), any()) } returns flowOf(progress)
 
-            val vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            val localVm = makeVm()
             advanceUntilIdle()
 
             val collected = mutableListOf<DownloadProgress?>()
             val collectorJob =
                 launch {
-                    vm.downloadProgress.collect { collected.add(it) }
+                    localVm.downloadProgress.collect { collected.add(it) }
                 }
 
-            assertNull(vm.downloadProgress.value)
+            assertNull(localVm.downloadProgress.value)
 
-            vm.startDownload(
+            localVm.startDownload(
                 name = "Test",
                 bounds = BoundingBox(minLat = 40.0, maxLat = 41.0, minLon = -75.0, maxLon = -74.0),
                 minZoom = 8,
                 maxZoom = 10,
+                viewportZoom = 9,
             )
             advanceUntilIdle()
 
             // Progress should have been emitted and then cleared
             assertTrue(collected.any { it != null })
-            assertNull(vm.downloadProgress.value)
+            assertNull(localVm.downloadProgress.value)
             collectorJob.cancel()
         }
 
@@ -161,13 +183,15 @@ class OfflineMapsViewModelTest {
         runTest {
             everySuspend { store.getRegions() } returns emptyList()
             everySuspend { store.saveRegion(any()) } returns 2L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/2.png"
             every { engine.download(any(), any()) } returns flowOf()
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             val bounds = BoundingBox(minLat = 40.0, maxLat = 41.0, minLon = -75.0, maxLon = -74.0)
-            vm.startDownload("Airport area", bounds, minZoom = 8, maxZoom = 12)
+            vm.startDownload("Airport area", bounds, minZoom = 8, maxZoom = 12, viewportZoom = 10)
             advanceUntilIdle()
 
             verifySuspend(mode = VerifyMode.exactly(1)) {
@@ -195,13 +219,22 @@ class OfflineMapsViewModelTest {
                 )
             everySuspend { store.getRegions() } returns emptyList()
             everySuspend { store.saveRegion(any()) } returns 3L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/3.png"
             every { engine.download(any(), any()) } returns flowOf()
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             val bounds = BoundingBox(minLat = 40.0, maxLat = 41.0, minLon = -75.0, maxLon = -74.0)
-            vm.startDownload("Custom area", bounds, minZoom = 8, maxZoom = 12, provider = customProvider)
+            vm.startDownload(
+                "Custom area",
+                bounds,
+                minZoom = 8,
+                maxZoom = 12,
+                viewportZoom = 10,
+                provider = customProvider,
+            )
             advanceUntilIdle()
 
             verifySuspend(mode = VerifyMode.exactly(1)) {
@@ -216,7 +249,7 @@ class OfflineMapsViewModelTest {
         runTest {
             everySuspend { store.getRegions() } returns emptyList()
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             verifySuspend(mode = VerifyMode.exactly(1)) { store.resetStuckDownloads() }
@@ -227,6 +260,8 @@ class OfflineMapsViewModelTest {
         runTest {
             val partialRegion = savedRegion.copy(status = DownloadStatus.PARTIAL)
             everySuspend { store.saveRegion(any()) } returns 1L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/1.png"
             val downloadFlow =
                 flow<DownloadProgress> {
                     emit(DownloadProgress(regionId = 1L, downloaded = 5L, total = 10L))
@@ -235,11 +270,11 @@ class OfflineMapsViewModelTest {
             every { engine.download(any(), any()) } returns downloadFlow
             everySuspend { store.getRegions() } returns listOf(partialRegion)
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             val bounds = BoundingBox(minLat = 40.0, maxLat = 41.0, minLon = -75.0, maxLon = -74.0)
-            vm.startDownload("Home", bounds, minZoom = 8, maxZoom = 12)
+            vm.startDownload("Home", bounds, minZoom = 8, maxZoom = 12, viewportZoom = 10)
             advanceUntilIdle()
 
             vm.cancelDownload()
@@ -262,7 +297,7 @@ class OfflineMapsViewModelTest {
             val progress = DownloadProgress(regionId = 1L, downloaded = 2L, total = 2L)
             every { engine.download(any(), any()) } returns flowOf(progress)
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             vm.retryDownload(failedRegion)
@@ -281,7 +316,7 @@ class OfflineMapsViewModelTest {
             val downloadingRegion = savedRegion.copy(status = DownloadStatus.DOWNLOADING)
             everySuspend { store.getRegions() } returns listOf(downloadingRegion)
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             vm.requestDeleteRegion(downloadingRegion)
@@ -297,12 +332,135 @@ class OfflineMapsViewModelTest {
             everySuspend { store.getRegions() } returns listOf(partialRegion)
             everySuspend { store.getFreedBytesForRegion(any()) } returns 0L
 
-            vm = OfflineMapsViewModel(store, engine, tileCache, downloadScopeHolder, testDispatcher)
+            vm = makeVm()
             advanceUntilIdle()
 
             vm.requestDeleteRegion(partialRegion)
             advanceUntilIdle()
 
             assertEquals(partialRegion, vm.pendingDeleteRegion.value)
+        }
+
+    @Test
+    fun `startDownload generates thumbnail and persists path`() =
+        runTest {
+            everySuspend { store.getRegions() } returns emptyList()
+            everySuspend { store.saveRegion(any()) } returns 42L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns true
+            every { thumbnailFileManager.thumbnailPath(42L) } returns "/cache/thumbnails/42.png"
+            everySuspend { store.updateThumbnail(any(), any(), any()) } returns Unit
+            every { engine.download(any(), any()) } returns flowOf()
+
+            vm = makeVm()
+            advanceUntilIdle()
+
+            val bounds = BoundingBox(minLat = 47.0, maxLat = 48.0, minLon = -122.5, maxLon = -122.0)
+            vm.startDownload("Test", bounds, minZoom = 8, maxZoom = 14, viewportZoom = 12)
+            advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) {
+                thumbnailGenerator.generate(
+                    bounds = bounds,
+                    providerId = any(),
+                    thumbnailZoom = 12,
+                    outputPath = "/cache/thumbnails/42.png",
+                )
+            }
+            verifySuspend(mode = VerifyMode.exactly(1)) {
+                store.updateThumbnail(42L, 12, "/cache/thumbnails/42.png")
+            }
+        }
+
+    @Test
+    fun `startDownload gracefully handles thumbnail failure`() =
+        runTest {
+            everySuspend { store.getRegions() } returns emptyList()
+            everySuspend { store.saveRegion(any()) } returns 42L
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns false
+            every { thumbnailFileManager.thumbnailPath(any()) } returns "/cache/thumbnails/42.png"
+            every { engine.download(any(), any()) } returns flowOf()
+
+            vm = makeVm()
+            advanceUntilIdle()
+
+            val bounds = BoundingBox(minLat = 47.0, maxLat = 48.0, minLon = -122.5, maxLon = -122.0)
+            vm.startDownload("Test", bounds, minZoom = 8, maxZoom = 14, viewportZoom = 12)
+            advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(0)) {
+                store.updateThumbnail(any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `onLoad auto-regenerates missing thumbnail for complete region`() =
+        runTest {
+            val regionWithMissingThumbnail =
+                savedRegion.copy(
+                    id = 5L,
+                    thumbnailZoom = 12,
+                    thumbnailPath = null,
+                    status = DownloadStatus.COMPLETE,
+                )
+            everySuspend { store.getRegions() } returns listOf(regionWithMissingThumbnail)
+            every { thumbnailFileManager.thumbnailPath(5L) } returns "/cache/thumbnails/5.png"
+            everySuspend { thumbnailGenerator.generate(any(), any(), any(), any()) } returns true
+            everySuspend { store.updateThumbnail(any(), any(), any()) } returns Unit
+
+            vm = makeVm()
+            advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(1)) {
+                thumbnailGenerator.generate(
+                    bounds = any(),
+                    providerId = any(),
+                    thumbnailZoom = 12,
+                    outputPath = "/cache/thumbnails/5.png",
+                )
+            }
+            verifySuspend(mode = VerifyMode.exactly(1)) {
+                store.updateThumbnail(5L, 12, "/cache/thumbnails/5.png")
+            }
+        }
+
+    @Test
+    fun `onLoad skips regeneration for incomplete region`() =
+        runTest {
+            val downloadingRegion =
+                savedRegion.copy(
+                    id = 6L,
+                    thumbnailZoom = 12,
+                    thumbnailPath = null,
+                    status = DownloadStatus.DOWNLOADING,
+                )
+            everySuspend { store.getRegions() } returns listOf(downloadingRegion)
+
+            vm = makeVm()
+            advanceUntilIdle()
+
+            verifySuspend(mode = VerifyMode.exactly(0)) {
+                thumbnailGenerator.generate(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `confirmDelete deletes thumbnail file`() =
+        runTest {
+            val regionToDelete = savedRegion.copy(id = 3L)
+            everySuspend { store.getRegions() } returns listOf(regionToDelete)
+            everySuspend { store.deleteRegion(any()) } returns Unit
+            everySuspend { store.getExclusiveTilesForRegion(any()) } returns emptyList()
+            everySuspend { store.getFreedBytesForRegion(any()) } returns 0L
+            every { thumbnailFileManager.delete(any()) } returns Unit
+
+            vm = makeVm()
+            advanceUntilIdle()
+
+            everySuspend { store.getRegions() } returns emptyList()
+            vm.requestDeleteRegion(regionToDelete)
+            vm.confirmDelete()
+            advanceUntilIdle()
+
+            verify(mode = VerifyMode.exactly(1)) { thumbnailFileManager.delete(3L) }
         }
 }

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
@@ -5,6 +5,10 @@ import com.jordankurtz.piawaremobile.map.cache.FileTileCache
 import com.jordankurtz.piawaremobile.map.cache.JvmCacheFileSystem
 import com.jordankurtz.piawaremobile.map.cache.TileCache
 import com.jordankurtz.piawaremobile.map.cache.TileCacheDatabase
+import com.jordankurtz.piawaremobile.map.offline.DesktopThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.DesktopThumbnailGenerator
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailGenerator
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -26,6 +30,18 @@ actual class TileCacheModule {
             ioDispatcher = ioDispatcher,
         )
     }
+
+    @Single
+    fun provideThumbnailGenerator(
+        @IODispatcher ioDispatcher: CoroutineDispatcher,
+    ): ThumbnailGenerator = DesktopThumbnailGenerator(
+        tileCacheDir = desktopCacheDir(),
+        ioDispatcher = ioDispatcher,
+    )
+
+    @Single
+    fun provideThumbnailFileManager(): ThumbnailFileManager =
+        DesktopThumbnailFileManager(File(desktopCacheDir().parent, "thumbnails"))
 }
 
 internal fun desktopCacheDir(): File {

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
@@ -32,7 +32,8 @@ actual class TileCacheModule {
     }
 
     @Single
-    fun provideThumbnailGenerator(
+    actual fun provideThumbnailGenerator(
+        contextWrapper: ContextWrapper,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
     ): ThumbnailGenerator =
         DesktopThumbnailGenerator(
@@ -41,7 +42,7 @@ actual class TileCacheModule {
         )
 
     @Single
-    fun provideThumbnailFileManager(): ThumbnailFileManager =
+    actual fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =
         DesktopThumbnailFileManager(File(desktopCacheDir().parent, "thumbnails"))
 }
 

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.desktop.kt
@@ -34,10 +34,11 @@ actual class TileCacheModule {
     @Single
     fun provideThumbnailGenerator(
         @IODispatcher ioDispatcher: CoroutineDispatcher,
-    ): ThumbnailGenerator = DesktopThumbnailGenerator(
-        tileCacheDir = desktopCacheDir(),
-        ioDispatcher = ioDispatcher,
-    )
+    ): ThumbnailGenerator =
+        DesktopThumbnailGenerator(
+            tileCacheDir = desktopCacheDir(),
+            ioDispatcher = ioDispatcher,
+        )
 
     @Single
     fun provideThumbnailFileManager(): ThumbnailFileManager =

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailFileManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailFileManager.kt
@@ -5,8 +5,7 @@ import java.io.File
 class DesktopThumbnailFileManager(
     private val thumbnailCacheDir: File,
 ) : ThumbnailFileManager {
-    override fun thumbnailPath(regionId: Long): String =
-        File(thumbnailCacheDir, "$regionId.png").absolutePath
+    override fun thumbnailPath(regionId: Long): String = File(thumbnailCacheDir, "$regionId.png").absolutePath
 
     override fun delete(regionId: Long) {
         File(thumbnailCacheDir, "$regionId.png").delete()

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailFileManager.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailFileManager.kt
@@ -1,0 +1,16 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import java.io.File
+
+class DesktopThumbnailFileManager(
+    private val thumbnailCacheDir: File,
+) : ThumbnailFileManager {
+    override fun thumbnailPath(regionId: Long): String =
+        File(thumbnailCacheDir, "$regionId.png").absolutePath
+
+    override fun delete(regionId: Long) {
+        File(thumbnailCacheDir, "$regionId.png").delete()
+    }
+
+    override fun exists(path: String): Boolean = File(path).exists()
+}

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailGenerator.kt
@@ -1,0 +1,60 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+class DesktopThumbnailGenerator(
+    private val tileCacheDir: File,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ThumbnailGenerator {
+
+    override suspend fun generate(
+        bounds: BoundingBox,
+        providerId: String,
+        thumbnailZoom: Int,
+        outputPath: String,
+    ): Boolean = withContext(ioDispatcher) {
+        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+        val gridW = colMax - colMin + 1
+        val gridH = rowMax - rowMin + 1
+
+        val stitched = BufferedImage(gridW * TILE_PX, gridH * TILE_PX, BufferedImage.TYPE_INT_ARGB)
+        val g = stitched.createGraphics()
+
+        for (col in colMin..colMax) {
+            for (row in rowMin..rowMax) {
+                val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
+                if (!tileFile.exists()) {
+                    g.dispose()
+                    return@withContext false
+                }
+                val tile = ImageIO.read(tileFile) ?: run {
+                    g.dispose()
+                    return@withContext false
+                }
+                g.drawImage(tile, (col - colMin) * TILE_PX, (row - rowMin) * TILE_PX, null)
+            }
+        }
+        g.dispose()
+
+        val thumbnail = BufferedImage(OUTPUT_PX, OUTPUT_PX, BufferedImage.TYPE_INT_ARGB)
+        val g2 = thumbnail.createGraphics()
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+        g2.drawImage(stitched, 0, 0, OUTPUT_PX, OUTPUT_PX, null)
+        g2.dispose()
+
+        val outFile = File(outputPath).also { it.parentFile?.mkdirs() }
+        ImageIO.write(thumbnail, "PNG", outFile)
+        true
+    }
+
+    private companion object {
+        const val TILE_PX = 256
+        const val OUTPUT_PX = 256
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jordankurtz/piawaremobile/map/offline/DesktopThumbnailGenerator.kt
@@ -11,47 +11,48 @@ class DesktopThumbnailGenerator(
     private val tileCacheDir: File,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ThumbnailGenerator {
-
     override suspend fun generate(
         bounds: BoundingBox,
         providerId: String,
         thumbnailZoom: Int,
         outputPath: String,
-    ): Boolean = withContext(ioDispatcher) {
-        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
-        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
-        val gridW = colMax - colMin + 1
-        val gridH = rowMax - rowMin + 1
+    ): Boolean =
+        withContext(ioDispatcher) {
+            val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+            val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+            val gridW = colMax - colMin + 1
+            val gridH = rowMax - rowMin + 1
 
-        val stitched = BufferedImage(gridW * TILE_PX, gridH * TILE_PX, BufferedImage.TYPE_INT_ARGB)
-        val g = stitched.createGraphics()
+            val stitched = BufferedImage(gridW * TILE_PX, gridH * TILE_PX, BufferedImage.TYPE_INT_ARGB)
+            val g = stitched.createGraphics()
 
-        for (col in colMin..colMax) {
-            for (row in rowMin..rowMax) {
-                val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
-                if (!tileFile.exists()) {
-                    g.dispose()
-                    return@withContext false
+            for (col in colMin..colMax) {
+                for (row in rowMin..rowMax) {
+                    val tileFile = File(tileCacheDir, "$providerId/$thumbnailZoom/$col/$row.png")
+                    if (!tileFile.exists()) {
+                        g.dispose()
+                        return@withContext false
+                    }
+                    val tile =
+                        ImageIO.read(tileFile) ?: run {
+                            g.dispose()
+                            return@withContext false
+                        }
+                    g.drawImage(tile, (col - colMin) * TILE_PX, (row - rowMin) * TILE_PX, null)
                 }
-                val tile = ImageIO.read(tileFile) ?: run {
-                    g.dispose()
-                    return@withContext false
-                }
-                g.drawImage(tile, (col - colMin) * TILE_PX, (row - rowMin) * TILE_PX, null)
             }
+            g.dispose()
+
+            val thumbnail = BufferedImage(OUTPUT_PX, OUTPUT_PX, BufferedImage.TYPE_INT_ARGB)
+            val g2 = thumbnail.createGraphics()
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+            g2.drawImage(stitched, 0, 0, OUTPUT_PX, OUTPUT_PX, null)
+            g2.dispose()
+
+            val outFile = File(outputPath).also { it.parentFile?.mkdirs() }
+            ImageIO.write(thumbnail, "PNG", outFile)
+            true
         }
-        g.dispose()
-
-        val thumbnail = BufferedImage(OUTPUT_PX, OUTPUT_PX, BufferedImage.TYPE_INT_ARGB)
-        val g2 = thumbnail.createGraphics()
-        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
-        g2.drawImage(stitched, 0, 0, OUTPUT_PX, OUTPUT_PX, null)
-        g2.dispose()
-
-        val outFile = File(outputPath).also { it.parentFile?.mkdirs() }
-        ImageIO.write(thumbnail, "PNG", outFile)
-        true
-    }
 
     private companion object {
         const val TILE_PX = 256

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/offline/MapRegionPickerScreenTest.kt
@@ -17,7 +17,7 @@ class MapRegionPickerScreenTest {
         runComposeUiTest {
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = {},
+                    onRegionSelected = { _, _ -> },
                     onDismiss = {},
                     mapLayer = {},
                 )
@@ -32,7 +32,7 @@ class MapRegionPickerScreenTest {
             var dismissed = false
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = {},
+                    onRegionSelected = { _, _ -> },
                     onDismiss = { dismissed = true },
                     mapLayer = {},
                 )
@@ -47,7 +47,7 @@ class MapRegionPickerScreenTest {
             var selectedBounds: BoundingBox? = null
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = { selectedBounds = it },
+                    onRegionSelected = { bounds, _ -> selectedBounds = bounds },
                     onDismiss = {},
                     mapLayer = {},
                 )
@@ -61,7 +61,7 @@ class MapRegionPickerScreenTest {
         runComposeUiTest {
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = {},
+                    onRegionSelected = { _, _ -> },
                     onDismiss = {},
                     mapLayer = {},
                 )
@@ -76,7 +76,7 @@ class MapRegionPickerScreenTest {
         runComposeUiTest {
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = {},
+                    onRegionSelected = { _, _ -> },
                     onDismiss = {},
                     mapLayer = {},
                 )
@@ -92,7 +92,7 @@ class MapRegionPickerScreenTest {
         runComposeUiTest {
             setContent {
                 MapRegionPickerContent(
-                    onRegionSelected = {},
+                    onRegionSelected = { _, _ -> },
                     onDismiss = {},
                     mapLayer = {},
                 )

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/DownloadRegionDialogTest.kt
@@ -22,7 +22,7 @@ class DownloadRegionDialogTest {
     fun displaysDialogElements() =
         runComposeUiTest {
             setContent {
-                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _ -> })
+                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _, _ -> })
             }
             onNodeWithText("Download Region").assertIsDisplayed()
             onNodeWithText("Region name").assertIsDisplayed()
@@ -37,7 +37,7 @@ class DownloadRegionDialogTest {
     fun downloadButtonDisabledWhenNameBlank() =
         runComposeUiTest {
             setContent {
-                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _ -> })
+                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _, _ -> })
             }
             onNodeWithText("Download").assertIsNotEnabled()
         }
@@ -51,7 +51,7 @@ class DownloadRegionDialogTest {
                     name = "My Region",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = bounds,
                 )
             }
@@ -66,7 +66,7 @@ class DownloadRegionDialogTest {
                     name = "My Region",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = null,
                 )
             }
@@ -83,7 +83,7 @@ class DownloadRegionDialogTest {
                     name = "World",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = bounds,
                 )
             }
@@ -104,7 +104,7 @@ class DownloadRegionDialogTest {
                         capturedName = it
                     },
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                 )
             }
             onNodeWithText("Region name").performClick()
@@ -117,11 +117,12 @@ class DownloadRegionDialogTest {
         runComposeUiTest {
             var dismissed = false
             setContent {
-                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = { dismissed = true }, onConfirm = {
-                        _,
-                        _,
-                    ->
-                })
+                DownloadRegionDialog(
+                    name = "",
+                    onNameChange = {},
+                    onDismiss = { dismissed = true },
+                    onConfirm = { _, _, _ -> },
+                )
             }
             onNodeWithText("Cancel").performClick()
             assertTrue(dismissed)
@@ -137,7 +138,7 @@ class DownloadRegionDialogTest {
                     name = "Airport Area",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> confirmCalled = true },
+                    onConfirm = { _, _, _ -> confirmCalled = true },
                     selectedBounds = bounds,
                 )
             }
@@ -149,7 +150,7 @@ class DownloadRegionDialogTest {
     fun selectOnMapButtonIsVisible() =
         runComposeUiTest {
             setContent {
-                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _ -> })
+                DownloadRegionDialog(name = "", onNameChange = {}, onDismiss = {}, onConfirm = { _, _, _ -> })
             }
             onNodeWithText("Select on map").assertIsDisplayed()
         }
@@ -163,7 +164,7 @@ class DownloadRegionDialogTest {
                     name = "",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     onSelectOnMap = { selectOnMapCalled = true },
                 )
             }
@@ -180,7 +181,7 @@ class DownloadRegionDialogTest {
                     name = "",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = bounds,
                 )
             }
@@ -195,7 +196,7 @@ class DownloadRegionDialogTest {
                     name = "",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = null,
                 )
             }
@@ -211,7 +212,7 @@ class DownloadRegionDialogTest {
                     name = "",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = bounds,
                 )
             }
@@ -226,7 +227,7 @@ class DownloadRegionDialogTest {
                     name = "",
                     onNameChange = {},
                     onDismiss = {},
-                    onConfirm = { _, _ -> },
+                    onConfirm = { _, _, _ -> },
                     selectedBounds = null,
                 )
             }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreenTest.kt
@@ -1,0 +1,79 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runComposeUiTest
+import com.jordankurtz.piawaremobile.map.offline.DownloadStatus
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
+import kotlin.io.path.createTempFile
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class OfflineMapsScreenTest {
+    @Test
+    fun placeholderIconShownWhenThumbnailPathIsNull() =
+        runComposeUiTest {
+            val region =
+                OfflineRegion(
+                    id = 1L,
+                    name = "Test Region",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    minLat = 40.0,
+                    maxLat = 41.0,
+                    minLon = -75.0,
+                    maxLon = -74.0,
+                    providerId = "osm",
+                    createdAt = 0L,
+                    status = DownloadStatus.COMPLETE,
+                    thumbnailPath = null,
+                )
+            setContent {
+                OfflineRegionItem(
+                    region = region,
+                    onDelete = {},
+                    onRetry = {},
+                    onCancel = {},
+                )
+            }
+            onNodeWithContentDescription("Map thumbnail placeholder").assertIsDisplayed()
+        }
+
+    @Test
+    fun asyncImageShownWhenThumbnailPathIsSet() =
+        runComposeUiTest {
+            val tmpFile = createTempFile(suffix = ".png").toFile()
+            val img = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+            ImageIO.write(img, "png", tmpFile)
+
+            val region =
+                OfflineRegion(
+                    id = 2L,
+                    name = "Test Region With Thumbnail",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    minLat = 40.0,
+                    maxLat = 41.0,
+                    minLon = -75.0,
+                    maxLon = -74.0,
+                    providerId = "osm",
+                    createdAt = 0L,
+                    status = DownloadStatus.COMPLETE,
+                    thumbnailPath = tmpFile.absolutePath,
+                )
+            setContent {
+                OfflineRegionItem(
+                    region = region,
+                    onDelete = {},
+                    onRetry = {},
+                    onCancel = {},
+                )
+            }
+            onNodeWithContentDescription("Map thumbnail").assertIsDisplayed()
+
+            tmpFile.delete()
+        }
+}

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
@@ -36,7 +36,8 @@ actual class TileCacheModule {
     }
 
     @Single
-    fun provideThumbnailGenerator(
+    actual fun provideThumbnailGenerator(
+        contextWrapper: ContextWrapper,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
     ): ThumbnailGenerator =
         IosThumbnailGenerator(
@@ -45,7 +46,8 @@ actual class TileCacheModule {
         )
 
     @Single
-    fun provideThumbnailFileManager(): ThumbnailFileManager = IosThumbnailFileManager(iosThumbnailDir())
+    actual fun provideThumbnailFileManager(contextWrapper: ContextWrapper): ThumbnailFileManager =
+        IosThumbnailFileManager(iosThumbnailDir())
 }
 
 private fun iosCacheDir(): String {

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
@@ -38,14 +38,14 @@ actual class TileCacheModule {
     @Single
     fun provideThumbnailGenerator(
         @IODispatcher ioDispatcher: CoroutineDispatcher,
-    ): ThumbnailGenerator = IosThumbnailGenerator(
-        tileCacheDir = iosCacheDir(),
-        ioDispatcher = ioDispatcher,
-    )
+    ): ThumbnailGenerator =
+        IosThumbnailGenerator(
+            tileCacheDir = iosCacheDir(),
+            ioDispatcher = ioDispatcher,
+        )
 
     @Single
-    fun provideThumbnailFileManager(): ThumbnailFileManager =
-        IosThumbnailFileManager(iosThumbnailDir())
+    fun provideThumbnailFileManager(): ThumbnailFileManager = IosThumbnailFileManager(iosThumbnailDir())
 }
 
 private fun iosCacheDir(): String {

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/di/modules/TileCacheModule.ios.kt
@@ -5,6 +5,10 @@ import com.jordankurtz.piawaremobile.map.cache.FileTileCache
 import com.jordankurtz.piawaremobile.map.cache.IosCacheFileSystem
 import com.jordankurtz.piawaremobile.map.cache.TileCache
 import com.jordankurtz.piawaremobile.map.cache.TileCacheDatabase
+import com.jordankurtz.piawaremobile.map.offline.IosThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.IosThumbnailGenerator
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailFileManager
+import com.jordankurtz.piawaremobile.map.offline.ThumbnailGenerator
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -22,16 +26,7 @@ actual class TileCacheModule {
         database: TileCacheDatabase,
         @IODispatcher ioDispatcher: CoroutineDispatcher,
     ): TileCache {
-        val cachePaths =
-            NSSearchPathForDirectoriesInDomains(
-                NSCachesDirectory,
-                NSUserDomainMask,
-                true,
-            )
-        val baseCacheDir = cachePaths.first() as String
-
-        @Suppress("CAST_NEVER_SUCCEEDS")
-        val cacheDir = (baseCacheDir as NSString).stringByAppendingPathComponent("map_tiles")
+        val cacheDir = iosCacheDir()
         val cacheFileSystem = IosCacheFileSystem(cacheDir)
         return FileTileCache(
             cacheFileSystem = cacheFileSystem,
@@ -39,4 +34,32 @@ actual class TileCacheModule {
             ioDispatcher = ioDispatcher,
         )
     }
+
+    @Single
+    fun provideThumbnailGenerator(
+        @IODispatcher ioDispatcher: CoroutineDispatcher,
+    ): ThumbnailGenerator = IosThumbnailGenerator(
+        tileCacheDir = iosCacheDir(),
+        ioDispatcher = ioDispatcher,
+    )
+
+    @Single
+    fun provideThumbnailFileManager(): ThumbnailFileManager =
+        IosThumbnailFileManager(iosThumbnailDir())
+}
+
+private fun iosCacheDir(): String {
+    val cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
+    val base = cachePaths.first() as String
+
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    return (base as NSString).stringByAppendingPathComponent("map_tiles")
+}
+
+private fun iosThumbnailDir(): String {
+    val cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
+    val base = cachePaths.first() as String
+
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    return (base as NSString).stringByAppendingPathComponent("thumbnails")
 }

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailFileManager.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailFileManager.kt
@@ -13,6 +13,5 @@ class IosThumbnailFileManager(
         NSFileManager.defaultManager.removeItemAtPath(thumbnailPath(regionId), error = null)
     }
 
-    override fun exists(path: String): Boolean =
-        NSFileManager.defaultManager.fileExistsAtPath(path)
+    override fun exists(path: String): Boolean = NSFileManager.defaultManager.fileExistsAtPath(path)
 }

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailFileManager.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailFileManager.kt
@@ -1,0 +1,18 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+
+@OptIn(ExperimentalForeignApi::class)
+class IosThumbnailFileManager(
+    private val thumbnailCacheDir: String,
+) : ThumbnailFileManager {
+    override fun thumbnailPath(regionId: Long): String = "$thumbnailCacheDir/$regionId.png"
+
+    override fun delete(regionId: Long) {
+        NSFileManager.defaultManager.removeItemAtPath(thumbnailPath(regionId), error = null)
+    }
+
+    override fun exists(path: String): Boolean =
+        NSFileManager.defaultManager.fileExistsAtPath(path)
+}

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailGenerator.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailGenerator.kt
@@ -1,0 +1,85 @@
+package com.jordankurtz.piawaremobile.map.offline
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.dataWithContentsOfFile
+import platform.Foundation.writeToFile
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
+import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
+
+class IosThumbnailGenerator(
+    private val tileCacheDir: String,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ThumbnailGenerator {
+
+    @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+    override suspend fun generate(
+        bounds: BoundingBox,
+        providerId: String,
+        thumbnailZoom: Int,
+        outputPath: String,
+    ): Boolean = withContext(ioDispatcher) {
+        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+        val gridW = colMax - colMin + 1
+        val gridH = rowMax - rowMin + 1
+        val stitchedW = (gridW * TILE_PX).toDouble()
+        val stitchedH = (gridH * TILE_PX).toDouble()
+
+        // Build stitched image
+        UIGraphicsBeginImageContextWithOptions(CGSizeMake(stitchedW, stitchedH), false, 1.0)
+        var allTilesPresent = true
+        for (col in colMin..colMax) {
+            for (row in rowMin..rowMax) {
+                val tilePath = "$tileCacheDir/$providerId/$thumbnailZoom/$col/$row.png"
+                val data = NSData.dataWithContentsOfFile(tilePath)
+                val tile = data?.let { UIImage.imageWithData(it) }
+                if (tile == null) {
+                    allTilesPresent = false
+                    break
+                }
+                val x = ((col - colMin) * TILE_PX).toDouble()
+                val y = ((row - rowMin) * TILE_PX).toDouble()
+                tile.drawInRect(CGRectMake(x, y, TILE_PX.toDouble(), TILE_PX.toDouble()))
+            }
+            if (!allTilesPresent) break
+        }
+        val stitched = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        if (!allTilesPresent || stitched == null) return@withContext false
+
+        // Scale to OUTPUT_PX × OUTPUT_PX
+        UIGraphicsBeginImageContextWithOptions(CGSizeMake(OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()), false, 1.0)
+        stitched.drawInRect(CGRectMake(0.0, 0.0, OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()))
+        val thumbnail = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        thumbnail ?: return@withContext false
+
+        val pngData = UIImagePNGRepresentation(thumbnail) ?: return@withContext false
+
+        // Ensure output directory exists
+        val outDir = outputPath.substringBeforeLast("/")
+        NSFileManager.defaultManager.createDirectoryAtPath(
+            outDir,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+        pngData.writeToFile(outputPath, atomically = true)
+        true
+    }
+
+    private companion object {
+        const val TILE_PX = 256
+        const val OUTPUT_PX = 256
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailGenerator.kt
+++ b/composeApp/src/iosMain/kotlin/com/jordankurtz/piawaremobile/map/offline/IosThumbnailGenerator.kt
@@ -18,65 +18,65 @@ class IosThumbnailGenerator(
     private val tileCacheDir: String,
     private val ioDispatcher: CoroutineDispatcher,
 ) : ThumbnailGenerator {
-
     @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
     override suspend fun generate(
         bounds: BoundingBox,
         providerId: String,
         thumbnailZoom: Int,
         outputPath: String,
-    ): Boolean = withContext(ioDispatcher) {
-        val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
-        val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
-        val gridW = colMax - colMin + 1
-        val gridH = rowMax - rowMin + 1
-        val stitchedW = (gridW * TILE_PX).toDouble()
-        val stitchedH = (gridH * TILE_PX).toDouble()
+    ): Boolean =
+        withContext(ioDispatcher) {
+            val (colMin, rowMin) = latLonToTile(bounds.maxLat, bounds.minLon, thumbnailZoom)
+            val (colMax, rowMax) = latLonToTile(bounds.minLat, bounds.maxLon, thumbnailZoom)
+            val gridW = colMax - colMin + 1
+            val gridH = rowMax - rowMin + 1
+            val stitchedW = (gridW * TILE_PX).toDouble()
+            val stitchedH = (gridH * TILE_PX).toDouble()
 
-        // Build stitched image
-        UIGraphicsBeginImageContextWithOptions(CGSizeMake(stitchedW, stitchedH), false, 1.0)
-        var allTilesPresent = true
-        for (col in colMin..colMax) {
-            for (row in rowMin..rowMax) {
-                val tilePath = "$tileCacheDir/$providerId/$thumbnailZoom/$col/$row.png"
-                val data = NSData.dataWithContentsOfFile(tilePath)
-                val tile = data?.let { UIImage.imageWithData(it) }
-                if (tile == null) {
-                    allTilesPresent = false
-                    break
+            // Build stitched image
+            UIGraphicsBeginImageContextWithOptions(CGSizeMake(stitchedW, stitchedH), false, 1.0)
+            var allTilesPresent = true
+            for (col in colMin..colMax) {
+                for (row in rowMin..rowMax) {
+                    val tilePath = "$tileCacheDir/$providerId/$thumbnailZoom/$col/$row.png"
+                    val data = NSData.dataWithContentsOfFile(tilePath)
+                    val tile = data?.let { UIImage.imageWithData(it) }
+                    if (tile == null) {
+                        allTilesPresent = false
+                        break
+                    }
+                    val x = ((col - colMin) * TILE_PX).toDouble()
+                    val y = ((row - rowMin) * TILE_PX).toDouble()
+                    tile.drawInRect(CGRectMake(x, y, TILE_PX.toDouble(), TILE_PX.toDouble()))
                 }
-                val x = ((col - colMin) * TILE_PX).toDouble()
-                val y = ((row - rowMin) * TILE_PX).toDouble()
-                tile.drawInRect(CGRectMake(x, y, TILE_PX.toDouble(), TILE_PX.toDouble()))
+                if (!allTilesPresent) break
             }
-            if (!allTilesPresent) break
+            val stitched = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+
+            if (!allTilesPresent || stitched == null) return@withContext false
+
+            // Scale to OUTPUT_PX × OUTPUT_PX
+            UIGraphicsBeginImageContextWithOptions(CGSizeMake(OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()), false, 1.0)
+            stitched.drawInRect(CGRectMake(0.0, 0.0, OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()))
+            val thumbnail = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+
+            thumbnail ?: return@withContext false
+
+            val pngData = UIImagePNGRepresentation(thumbnail) ?: return@withContext false
+
+            // Ensure output directory exists
+            val outDir = outputPath.substringBeforeLast("/")
+            NSFileManager.defaultManager.createDirectoryAtPath(
+                outDir,
+                withIntermediateDirectories = true,
+                attributes = null,
+                error = null,
+            )
+            pngData.writeToFile(outputPath, atomically = true)
+            true
         }
-        val stitched = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        if (!allTilesPresent || stitched == null) return@withContext false
-
-        // Scale to OUTPUT_PX × OUTPUT_PX
-        UIGraphicsBeginImageContextWithOptions(CGSizeMake(OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()), false, 1.0)
-        stitched.drawInRect(CGRectMake(0.0, 0.0, OUTPUT_PX.toDouble(), OUTPUT_PX.toDouble()))
-        val thumbnail = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        thumbnail ?: return@withContext false
-
-        val pngData = UIImagePNGRepresentation(thumbnail) ?: return@withContext false
-
-        // Ensure output directory exists
-        val outDir = outputPath.substringBeforeLast("/")
-        NSFileManager.defaultManager.createDirectoryAtPath(
-            outDir,
-            withIntermediateDirectories = true,
-            attributes = null,
-            error = null,
-        )
-        pngData.writeToFile(outputPath, atomically = true)
-        true
-    }
 
     private companion object {
         const val TILE_PX = 256

--- a/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/jordankurtz/piawaremobile/map/offline/SqlDelightOfflineTileStoreTest.kt
@@ -303,6 +303,31 @@ class SqlDelightOfflineTileStoreTest {
             assertFalse(store.isPinned(zoomLevel = 8, col = 3, row = 4, providerId = "osm"))
         }
 
+    @Test
+    fun `updateThumbnail persists zoom and path`() =
+        runTest(testDispatcher) {
+            val regionId =
+                store.saveRegion(
+                    OfflineRegion(
+                        name = "Test",
+                        minZoom = 8,
+                        maxZoom = 14,
+                        minLat = 47.0,
+                        maxLat = 48.0,
+                        minLon = -122.5,
+                        maxLon = -122.0,
+                        providerId = "openstreetmap",
+                        createdAt = 0L,
+                    ),
+                )
+
+            store.updateThumbnail(regionId, zoom = 12, path = "/cache/thumbnails/1.png")
+
+            val region = store.getRegion(regionId)
+            assertEquals(12, region?.thumbnailZoom)
+            assertEquals("/cache/thumbnails/1.png", region?.thumbnailPath)
+        }
+
     private fun insertTile(
         zoom: Int,
         col: Int,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ detekt = "1.23.8"
 kover = "0.9.1"
 sqldelight = "2.0.2"
 androidx-compose-ui-test = "1.9.3"
+coil = "3.2.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -79,6 +80,7 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 
 
 [plugins]


### PR DESCRIPTION
Closes #151

## Summary

- Stitches cached map tiles into a 256×256 PNG thumbnail at region-creation time, using the viewport zoom level captured from the region picker
- Stores `thumbnailZoom` and `thumbnailPath` on `OfflineRegion` (SQLDelight migration 3→4); auto-regenerates missing thumbnails on load for `COMPLETE` regions
- Displays a 64×64dp leading image slot in the offline maps list — `AsyncImage` when a thumbnail exists, centered `Icons.Outlined.Map` placeholder otherwise
- Cleans up the thumbnail file on region deletion

## Test Plan

- [ ] Unit tests: `startDownload` generates thumbnail and persists path; graceful failure path; auto-regeneration triggers for COMPLETE regions and skips non-COMPLETE; `confirmDelete` deletes thumbnail file; `updateThumbnail` persists zoom + path to DB
- [ ] Desktop UI tests: placeholder shown when `thumbnailPath = null`; `AsyncImage` rendered when `thumbnailPath` is set
- [ ] Android instrumented tests run in CI on `pixel_6` and `pixel_tablet`
- [ ] `ktlintCheck`, `detekt`, `testDebugUnitTest`, `desktopTest` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)