### PR TITLE
Eliminate !! assertions in regenerateMissingThumbnails

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/offline/OfflineMapsViewModel.kt
@@ -196,21 +196,23 @@ class OfflineMapsViewModel(
     private suspend fun regenerateMissingThumbnails(regions: List<OfflineRegion>) {
         regions
             .filter { region ->
+                val existingPath = region.thumbnailPath
                 region.thumbnailZoom != null &&
                     region.status == DownloadStatus.COMPLETE &&
-                    (region.thumbnailPath == null || !thumbnailFileManager.exists(region.thumbnailPath!!))
+                    (existingPath == null || !thumbnailFileManager.exists(existingPath))
             }
             .forEach { region ->
+                val zoom = region.thumbnailZoom ?: return@forEach
                 val path = thumbnailFileManager.thumbnailPath(region.id)
                 val ok =
                     thumbnailGenerator.generate(
                         bounds = BoundingBox(region.minLat, region.maxLat, region.minLon, region.maxLon),
                         providerId = region.providerId,
-                        thumbnailZoom = region.thumbnailZoom!!,
+                        thumbnailZoom = zoom,
                         outputPath = path,
                     )
                 if (ok) {
-                    store.updateThumbnail(region.id, region.thumbnailZoom!!, path)
+                    store.updateThumbnail(region.id, zoom, path)
                     _regions.value = store.getRegions()
                 }
             }


### PR DESCRIPTION
## Summary
- Binds `val existingPath = region.thumbnailPath` in the `filter` lambda so the compiler can smart-cast nullability, removing `thumbnailPath!!`
- Binds `val zoom = region.thumbnailZoom ?: return@forEach` in the `forEach` lambda, replacing two `thumbnailZoom!!` usages with a compiler-verified local

The `!!` usages were safe by upstream control flow, but brittle — a change to the filter condition could silently introduce a crash. This makes the invariants explicit and enforced by the type system.

Closes #170

## Test plan
- [ ] Build compiles cleanly (`compileDebugKotlinAndroid`)
- [ ] Manually verify offline region thumbnails still generate on app launch when missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)