### PR TITLE
Abstract MapState behind MapStateController for cross-platform testability

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/MapModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/MapModule.kt
@@ -1,6 +1,8 @@
 package com.jordankurtz.piawaremobile.di.modules
 
 import com.jordankurtz.piawaremobile.di.annotations.IODispatcher
+import com.jordankurtz.piawaremobile.map.MapComposeStateController
+import com.jordankurtz.piawaremobile.map.MapStateController
 import com.jordankurtz.piawaremobile.map.TileProviderConfig
 import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
@@ -12,6 +14,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.runBlocking
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 
@@ -31,4 +34,7 @@ class MapModule {
             .map { TileProviders.findById(it.mapProviderId) }
             .stateIn(scope = applicationScope, started = SharingStarted.Eagerly, initialValue = initial)
     }
+
+    @Factory
+    fun provideMapStateController(): MapStateController = MapComposeStateController()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
@@ -29,19 +29,21 @@ import ovh.plrapps.mapcompose.ui.state.MapState
 import kotlin.math.pow
 
 class MapComposeStateController : MapStateController {
-    val mapState: MapState = MapState(
-        levelCount = MAX_LEVEL + 1,
-        mapSize,
-        mapSize,
-        workerCount = 16,
-    ) {
-        minimumScaleMode(Forced((1 / 2.0.pow(MAX_LEVEL - MIN_LEVEL))))
-    }
+    val mapState: MapState =
+        MapState(
+            levelCount = MAX_LEVEL + 1,
+            mapSize,
+            mapSize,
+            workerCount = 16,
+        ) {
+            minimumScaleMode(Forced((1 / 2.0.pow(MAX_LEVEL - MIN_LEVEL))))
+        }
 
-    override val scrollAndScaleFlow: Flow<MapScrollPosition> = snapshotFlow {
-        val s = mapState.scroll
-        MapScrollPosition(s.x, s.y, mapState.scale)
-    }
+    override val scrollAndScaleFlow: Flow<MapScrollPosition> =
+        snapshotFlow {
+            val s = mapState.scroll
+            MapScrollPosition(s.x, s.y, mapState.scale)
+        }
 
     override fun addLayer(provider: TileStreamProvider): String = mapState.addLayer(provider)
 
@@ -57,29 +59,52 @@ class MapComposeStateController : MapStateController {
         mapState.onTouchDown { handler() }
     }
 
-    override fun replaceLayer(layerId: String, provider: TileStreamProvider): String? =
-        mapState.replaceLayer(layerId, provider)
+    override fun replaceLayer(
+        layerId: String,
+        provider: TileStreamProvider,
+    ): String? = mapState.replaceLayer(layerId, provider)
 
-    override suspend fun setScroll(x: Double, y: Double) = mapState.setScroll(x, y)
+    override suspend fun setScroll(
+        x: Double,
+        y: Double,
+    ) = mapState.setScroll(x, y)
 
     override var scale: Double
         get() = mapState.scale
-        set(value) { mapState.scale = value }
+        set(value) {
+            mapState.scale = value
+        }
 
-    override suspend fun scrollTo(x: Double, y: Double, animationSpec: AnimationSpec<Float>) =
-        mapState.scrollTo(x, y, animationSpec = animationSpec)
+    override suspend fun scrollTo(
+        x: Double,
+        y: Double,
+        animationSpec: AnimationSpec<Float>,
+    ) = mapState.scrollTo(x, y, animationSpec = animationSpec)
 
-    override suspend fun scrollTo(area: BoundingBox, padding: Offset, animationSpec: AnimationSpec<Float>) =
-        mapState.scrollTo(area = area, padding = padding, animationSpec = animationSpec)
+    override suspend fun scrollTo(
+        area: BoundingBox,
+        padding: Offset,
+        animationSpec: AnimationSpec<Float>,
+    ) = mapState.scrollTo(area = area, padding = padding, animationSpec = animationSpec)
 
-    override fun addMarker(id: String, x: Double, y: Double, relativeOffset: Offset, content: @Composable () -> Unit) =
-        mapState.addMarker(id, x, y, relativeOffset = relativeOffset, c = content)
+    override fun addMarker(
+        id: String,
+        x: Double,
+        y: Double,
+        relativeOffset: Offset,
+        content: @Composable () -> Unit,
+    ) = mapState.addMarker(id, x, y, relativeOffset = relativeOffset, c = content)
 
     override fun removeMarker(id: String) {
         mapState.removeMarker(id)
     }
 
-    override fun addPath(id: String, color: Color, width: Dp, init: PathDataBuilder.() -> Unit) {
+    override fun addPath(
+        id: String,
+        color: Color,
+        width: Dp,
+        init: PathDataBuilder.() -> Unit,
+    ) {
         mapState.addPath(id, color = color, width = width, builder = init)
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
@@ -110,5 +110,5 @@ class MapComposeStateController : MapStateController {
 
     override fun removePath(id: String) = mapState.removePath(id)
 
-    override fun shutdown() = mapState.shutdown()
+    fun shutdown() = mapState.shutdown()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
@@ -1,0 +1,89 @@
+package com.jordankurtz.piawaremobile.map
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import ovh.plrapps.mapcompose.api.BoundingBox
+import ovh.plrapps.mapcompose.api.addLayer
+import ovh.plrapps.mapcompose.api.addMarker
+import ovh.plrapps.mapcompose.api.addPath
+import ovh.plrapps.mapcompose.api.onMarkerClick
+import ovh.plrapps.mapcompose.api.onTap
+import ovh.plrapps.mapcompose.api.onTouchDown
+import ovh.plrapps.mapcompose.api.removeMarker
+import ovh.plrapps.mapcompose.api.removePath
+import ovh.plrapps.mapcompose.api.replaceLayer
+import ovh.plrapps.mapcompose.api.scale
+import ovh.plrapps.mapcompose.api.scroll
+import ovh.plrapps.mapcompose.api.scrollTo
+import ovh.plrapps.mapcompose.api.setScroll
+import ovh.plrapps.mapcompose.core.TileStreamProvider
+import ovh.plrapps.mapcompose.ui.layout.Forced
+import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
+import ovh.plrapps.mapcompose.ui.state.MapState
+import kotlin.math.pow
+
+class MapComposeStateController : MapStateController {
+    val mapState: MapState = MapState(
+        levelCount = MAX_LEVEL + 1,
+        mapSize,
+        mapSize,
+        workerCount = 16,
+    ) {
+        minimumScaleMode(Forced((1 / 2.0.pow(MAX_LEVEL - MIN_LEVEL))))
+    }
+
+    override val scrollAndScaleFlow: Flow<MapScrollPosition> = snapshotFlow {
+        val s = mapState.scroll
+        MapScrollPosition(s.x, s.y, mapState.scale)
+    }
+
+    override fun addLayer(provider: TileStreamProvider): String = mapState.addLayer(provider)
+
+    override fun onMarkerClick(handler: (id: String) -> Unit) {
+        mapState.onMarkerClick { id, _, _ -> handler(id) }
+    }
+
+    override fun onTap(handler: () -> Unit) {
+        mapState.onTap { _, _ -> handler() }
+    }
+
+    override fun onTouchDown(handler: () -> Unit) {
+        mapState.onTouchDown { handler() }
+    }
+
+    override fun replaceLayer(layerId: String, provider: TileStreamProvider): String? =
+        mapState.replaceLayer(layerId, provider)
+
+    override suspend fun setScroll(x: Double, y: Double) = mapState.setScroll(x, y)
+
+    override var scale: Double
+        get() = mapState.scale
+        set(value) { mapState.scale = value }
+
+    override suspend fun scrollTo(x: Double, y: Double, animationSpec: AnimationSpec<Float>) =
+        mapState.scrollTo(x, y, animationSpec = animationSpec)
+
+    override suspend fun scrollTo(area: BoundingBox, padding: Offset, animationSpec: AnimationSpec<Float>) =
+        mapState.scrollTo(area = area, padding = padding, animationSpec = animationSpec)
+
+    override fun addMarker(id: String, x: Double, y: Double, relativeOffset: Offset, content: @Composable () -> Unit) =
+        mapState.addMarker(id, x, y, relativeOffset = relativeOffset, c = content)
+
+    override fun removeMarker(id: String) {
+        mapState.removeMarker(id)
+    }
+
+    override fun addPath(id: String, color: Color, width: Dp, init: PathDataBuilder.() -> Unit) {
+        mapState.addPath(id, color = color, width = width, builder = init)
+    }
+
+    override fun removePath(id: String) = mapState.removePath(id)
+
+    override fun shutdown() = mapState.shutdown()
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
@@ -67,6 +67,4 @@ interface MapStateController {
     )
 
     fun removePath(id: String)
-
-    fun shutdown()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
@@ -1,0 +1,66 @@
+package com.jordankurtz.piawaremobile.map
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import kotlinx.coroutines.flow.Flow
+import ovh.plrapps.mapcompose.api.BoundingBox
+import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
+import ovh.plrapps.mapcompose.core.TileStreamProvider
+
+data class MapScrollPosition(val scrollX: Double, val scrollY: Double, val scale: Double)
+
+interface MapStateController {
+    val scrollAndScaleFlow: Flow<MapScrollPosition>
+
+    fun addLayer(provider: TileStreamProvider): String
+
+    fun onMarkerClick(handler: (id: String) -> Unit)
+
+    fun onTap(handler: () -> Unit)
+
+    fun onTouchDown(handler: () -> Unit)
+
+    fun replaceLayer(layerId: String, provider: TileStreamProvider): String?
+
+    suspend fun setScroll(x: Double, y: Double)
+
+    var scale: Double
+
+    suspend fun scrollTo(
+        x: Double,
+        y: Double,
+        animationSpec: AnimationSpec<Float> = SpringSpec(stiffness = Spring.StiffnessLow),
+    )
+
+    suspend fun scrollTo(
+        area: BoundingBox,
+        padding: Offset,
+        animationSpec: AnimationSpec<Float> = SpringSpec(stiffness = Spring.StiffnessLow),
+    )
+
+    fun addMarker(
+        id: String,
+        x: Double,
+        y: Double,
+        relativeOffset: Offset,
+        content: @Composable () -> Unit,
+    )
+
+    fun removeMarker(id: String)
+
+    fun addPath(
+        id: String,
+        color: Color,
+        width: Dp,
+        init: PathDataBuilder.() -> Unit,
+    )
+
+    fun removePath(id: String)
+
+    fun shutdown()
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.flow.Flow
 import ovh.plrapps.mapcompose.api.BoundingBox
-import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
 import ovh.plrapps.mapcompose.core.TileStreamProvider
+import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
 
 data class MapScrollPosition(val scrollX: Double, val scrollY: Double, val scale: Double)
 
@@ -25,9 +25,15 @@ interface MapStateController {
 
     fun onTouchDown(handler: () -> Unit)
 
-    fun replaceLayer(layerId: String, provider: TileStreamProvider): String?
+    fun replaceLayer(
+        layerId: String,
+        provider: TileStreamProvider,
+    ): String?
 
-    suspend fun setScroll(x: Double, y: Double)
+    suspend fun setScroll(
+        x: Double,
+        y: Double,
+    )
 
     var scale: Double
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -4,11 +4,9 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
@@ -34,7 +32,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -42,21 +39,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.annotation.Factory
 import ovh.plrapps.mapcompose.api.BoundingBox
-import ovh.plrapps.mapcompose.api.addLayer
-import ovh.plrapps.mapcompose.api.addMarker
-import ovh.plrapps.mapcompose.api.addPath
-import ovh.plrapps.mapcompose.api.onMarkerClick
-import ovh.plrapps.mapcompose.api.onTap
-import ovh.plrapps.mapcompose.api.onTouchDown
-import ovh.plrapps.mapcompose.api.removeMarker
-import ovh.plrapps.mapcompose.api.removePath
-import ovh.plrapps.mapcompose.api.replaceLayer
-import ovh.plrapps.mapcompose.api.scale
-import ovh.plrapps.mapcompose.api.scroll
-import ovh.plrapps.mapcompose.api.scrollTo
-import ovh.plrapps.mapcompose.api.setScroll
 import ovh.plrapps.mapcompose.core.TileStreamProvider
-import ovh.plrapps.mapcompose.ui.layout.Forced
 import ovh.plrapps.mapcompose.ui.state.MapState
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.ic_plane
@@ -78,8 +61,13 @@ class MapViewModel(
     private val saveMapStateUseCase: SaveMapStateUseCase,
     private val loadSettingsUseCase: LoadSettingsUseCase,
     private val tileCacheStatsTracker: TileCacheStatsTracker,
+    internal val mapStateController: MapStateController,
 ) : ViewModel() {
+
     val activeProvider: StateFlow<TileProviderConfig> = providerConfigFlow
+
+    /** The underlying MapCompose state — for use by composables only, not for testing. */
+    val state: MapState get() = (mapStateController as MapComposeStateController).mapState
 
     private var saveStateJob: Job? = null
     private var settings: Settings? = null
@@ -107,35 +95,29 @@ class MapViewModel(
 
     private val _trailSelectedAircraft = MutableStateFlow<String?>(null)
 
-    val state =
-        MapState(levelCount = MAX_LEVEL + 1, mapSize, mapSize, workerCount = 16) {
-            minimumScaleMode(Forced((1 / 2.0.pow(MAX_LEVEL - MIN_LEVEL))))
-        }.apply {
-            tileLayerId = addLayer(mapProvider)
+    init {
+        tileLayerId = mapStateController.addLayer(mapProvider)
 
-            onMarkerClick { id, _, _ ->
-                if (previousAircraftMarkerIds.contains(id)) {
-                    val newSelection = if (_selectedAircraft.value == id) null else id
-                    _selectedAircraft.value = newSelection
-                    _trailSelectedAircraft.value = newSelection
-                    onAircraftTrailsUpdated(lastTrails)
-                }
+        mapStateController.onMarkerClick { id ->
+            if (previousAircraftMarkerIds.contains(id)) {
+                val newSelection = if (_selectedAircraft.value == id) null else id
+                _selectedAircraft.value = newSelection
+                _trailSelectedAircraft.value = newSelection
+                onAircraftTrailsUpdated(lastTrails)
             }
-
-            onTap { _, _ ->
-                // Deselect when tapping on empty space
-                if (_selectedAircraft.value != null) {
-                    _selectedAircraft.value = null
-                    _followingAircraft.value = null
-                    _trailSelectedAircraft.value = null
-                    onAircraftTrailsUpdated(lastTrails)
-                }
-            }
-
-            onTouchDown { onMapTouchDown() }
         }
 
-    init {
+        mapStateController.onTap {
+            if (_selectedAircraft.value != null) {
+                _selectedAircraft.value = null
+                _followingAircraft.value = null
+                _trailSelectedAircraft.value = null
+                onAircraftTrailsUpdated(lastTrails)
+            }
+        }
+
+        mapStateController.onTouchDown { onMapTouchDown() }
+
         viewModelScope.launch {
             loadSettingsUseCase().collect {
                 when (it) {
@@ -157,7 +139,7 @@ class MapViewModel(
 
         viewModelScope.launch {
             providerConfigFlow.drop(1).collect { // skip initial — already loaded
-                state.replaceLayer(tileLayerId, mapProvider)?.let { newId ->
+                mapStateController.replaceLayer(tileLayerId, mapProvider)?.let { newId ->
                     tileLayerId = newId
                 }
             }
@@ -208,19 +190,19 @@ class MapViewModel(
     private suspend fun loadMapState() {
         val savedState = getSavedMapStateUseCase()
         Logger.d("Restored map state $savedState")
-        state.setScroll(savedState.scrollX, savedState.scrollY)
-        state.scale = savedState.zoom
+        mapStateController.setScroll(savedState.scrollX, savedState.scrollY)
+        mapStateController.scale = savedState.zoom
     }
 
     private fun startSaveMapStateJob() {
         saveStateJob =
             viewModelScope.launch {
-                snapshotFlow { Pair(state.scroll, state.scale) }
+                mapStateController.scrollAndScaleFlow
                     .debounce(500.milliseconds)
-                    .onEach { (scroll, scale) ->
-                        if (scroll.x > 0.0 && scroll.y > 0.0) {
-                            saveMapStateUseCase(scroll.x, scroll.y, scale)
-                            Logger.d("Saved map state $scroll, $scale")
+                    .onEach { (scrollX, scrollY, scale) ->
+                        if (scrollX > 0.0 && scrollY > 0.0) {
+                            saveMapStateUseCase(scrollX, scrollY, scale)
+                            Logger.d("Saved map state $scrollX, $scrollY, $scale")
                         }
                     }.launchIn(this)
             }
@@ -229,7 +211,7 @@ class MapViewModel(
     fun onReceiverLocation(receiver: Map.Entry<Server, Location>) =
         viewModelScope.launch {
             val (x, y) = receiver.value.projected
-            state.addMarker(
+            mapStateController.addMarker(
                 id = receiver.key.id.toString(),
                 x = x,
                 y = y,
@@ -251,7 +233,7 @@ class MapViewModel(
         viewModelScope.launch {
             val (x, y) = location.projected
             Logger.d("Scrolling map to $x, $y")
-            state.scrollTo(x, y)
+            mapStateController.scrollTo(x, y)
         }
     }
 
@@ -261,7 +243,7 @@ class MapViewModel(
             null -> return
             is FitTarget.SinglePoint -> {
                 viewModelScope.launch {
-                    state.scrollTo(
+                    mapStateController.scrollTo(
                         target.x,
                         target.y,
                         animationSpec = SpringSpec(stiffness = Spring.StiffnessLow),
@@ -278,7 +260,7 @@ class MapViewModel(
                         yBottom = target.yBottom,
                     )
                 viewModelScope.launch {
-                    state.scrollTo(
+                    mapStateController.scrollTo(
                         area = boundingBox,
                         padding = Offset(x = 0.15f, y = 0.15f),
                         animationSpec = SpringSpec(stiffness = Spring.StiffnessLow),
@@ -303,8 +285,8 @@ class MapViewModel(
             recenterOnLocation(location)
         }
         val (x, y) = location.projected
-        state.removeMarker(USER_LOCATION_MARKER_ID)
-        state.addMarker(
+        mapStateController.removeMarker(USER_LOCATION_MARKER_ID)
+        mapStateController.addMarker(
             id = USER_LOCATION_MARKER_ID,
             x = x,
             y = y,
@@ -319,7 +301,7 @@ class MapViewModel(
     }
 
     fun onAircraftUpdated(aircraft: List<AircraftWithServers>) {
-        previousAircraftMarkerIds.forEach(state::removeMarker)
+        previousAircraftMarkerIds.forEach(mapStateController::removeMarker)
         previousAircraftMarkerIds.clear()
 
         var followedAircraftPosition: Pair<Double, Double>? = null
@@ -333,7 +315,7 @@ class MapViewModel(
                 followedAircraftPosition = location
             }
 
-            state.addMarker(
+            mapStateController.addMarker(
                 id = plane.hex.also { previousAircraftMarkerIds.add(it) },
                 x = location.first,
                 y = location.second,
@@ -353,7 +335,7 @@ class MapViewModel(
 
         followedAircraftPosition?.let { (x, y) ->
             viewModelScope.launch {
-                state.scrollTo(x, y)
+                mapStateController.scrollTo(x, y)
             }
         }
 
@@ -392,7 +374,6 @@ class MapViewModel(
         trail: AircraftTrail,
     ) {
         if (trail.positions.size >= 2) {
-            // Group consecutive positions by altitude color to reduce path count
             val colorSegments = groupPositionsByAltitudeColor(trail.positions)
 
             colorSegments.forEachIndexed { index, segment ->
@@ -405,7 +386,7 @@ class MapViewModel(
                             doProjection(pos.latitude, pos.longitude)
                         }
 
-                    state.addPath(
+                    mapStateController.addPath(
                         id = id,
                         color = segment.color,
                         width = 1.5.dp,
@@ -436,8 +417,6 @@ class MapViewModel(
             if (posColor == currentColor) {
                 currentSegment.positions.add(pos)
             } else {
-                // End current segment and start new one
-                // Add last point of current segment as first point of new segment for continuity
                 segments.add(currentSegment)
                 currentColor = posColor
                 currentSegment = ColorSegment(currentColor, mutableListOf(positions[i - 1], pos))
@@ -449,7 +428,7 @@ class MapViewModel(
     }
 
     private fun clearPaths() {
-        previousPathIds.forEach { state.removePath(it) }
+        previousPathIds.forEach { mapStateController.removePath(it) }
         previousPathIds.clear()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -429,4 +429,9 @@ class MapViewModel(
         previousPathIds.forEach { mapStateController.removePath(it) }
         previousPathIds.clear()
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        (mapStateController as? MapComposeStateController)?.shutdown()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -46,7 +46,6 @@ import piawaremobile.composeapp.generated.resources.ic_plane
 import piawaremobile.composeapp.generated.resources.ic_receiver
 import piawaremobile.composeapp.generated.resources.ic_user_location
 import piawaremobile.composeapp.generated.resources.user_location_content_description
-import kotlin.math.pow
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val USER_LOCATION_MARKER_ID = "user_location"
@@ -63,7 +62,6 @@ class MapViewModel(
     private val tileCacheStatsTracker: TileCacheStatsTracker,
     internal val mapStateController: MapStateController,
 ) : ViewModel() {
-
     val activeProvider: StateFlow<TileProviderConfig> = providerConfigFlow
 
     /** The underlying MapCompose state — for use by composables only, not for testing. */

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
@@ -22,21 +22,46 @@ class FakeMapStateController : MapStateController {
 
     override fun onTouchDown(handler: () -> Unit) = Unit
 
-    override fun replaceLayer(layerId: String, provider: TileStreamProvider): String? = null
+    override fun replaceLayer(
+        layerId: String,
+        provider: TileStreamProvider,
+    ): String? = null
 
-    override suspend fun setScroll(x: Double, y: Double) = Unit
+    override suspend fun setScroll(
+        x: Double,
+        y: Double,
+    ) = Unit
 
     override var scale: Double = 1.0
 
-    override suspend fun scrollTo(x: Double, y: Double, animationSpec: AnimationSpec<Float>) = Unit
+    override suspend fun scrollTo(
+        x: Double,
+        y: Double,
+        animationSpec: AnimationSpec<Float>,
+    ) = Unit
 
-    override suspend fun scrollTo(area: BoundingBox, padding: Offset, animationSpec: AnimationSpec<Float>) = Unit
+    override suspend fun scrollTo(
+        area: BoundingBox,
+        padding: Offset,
+        animationSpec: AnimationSpec<Float>,
+    ) = Unit
 
-    override fun addMarker(id: String, x: Double, y: Double, relativeOffset: Offset, content: @Composable () -> Unit) = Unit
+    override fun addMarker(
+        id: String,
+        x: Double,
+        y: Double,
+        relativeOffset: Offset,
+        content: @Composable () -> Unit,
+    ) = Unit
 
     override fun removeMarker(id: String) = Unit
 
-    override fun addPath(id: String, color: Color, width: Dp, init: PathDataBuilder.() -> Unit) = Unit
+    override fun addPath(
+        id: String,
+        color: Color,
+        width: Dp,
+        init: PathDataBuilder.() -> Unit,
+    ) = Unit
 
     override fun removePath(id: String) = Unit
 

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
@@ -64,6 +64,4 @@ class FakeMapStateController : MapStateController {
     ) = Unit
 
     override fun removePath(id: String) = Unit
-
-    override fun shutdown() = Unit
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
@@ -1,0 +1,44 @@
+package com.jordankurtz.piawaremobile.map
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import ovh.plrapps.mapcompose.api.BoundingBox
+import ovh.plrapps.mapcompose.core.TileStreamProvider
+import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
+
+class FakeMapStateController : MapStateController {
+    override val scrollAndScaleFlow: Flow<MapScrollPosition> = emptyFlow()
+
+    override fun addLayer(provider: TileStreamProvider): String = "fake-layer-id"
+
+    override fun onMarkerClick(handler: (id: String) -> Unit) = Unit
+
+    override fun onTap(handler: () -> Unit) = Unit
+
+    override fun onTouchDown(handler: () -> Unit) = Unit
+
+    override fun replaceLayer(layerId: String, provider: TileStreamProvider): String? = null
+
+    override suspend fun setScroll(x: Double, y: Double) = Unit
+
+    override var scale: Double = 1.0
+
+    override suspend fun scrollTo(x: Double, y: Double, animationSpec: AnimationSpec<Float>) = Unit
+
+    override suspend fun scrollTo(area: BoundingBox, padding: Offset, animationSpec: AnimationSpec<Float>) = Unit
+
+    override fun addMarker(id: String, x: Double, y: Double, relativeOffset: Offset, content: @Composable () -> Unit) = Unit
+
+    override fun removeMarker(id: String) = Unit
+
+    override fun addPath(id: String, color: Color, width: Dp, init: PathDataBuilder.() -> Unit) = Unit
+
+    override fun removePath(id: String) = Unit
+
+    override fun shutdown() = Unit
+}

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -80,7 +80,6 @@ class MapViewModelTest {
     @AfterTest
     fun tearDown() {
         viewModel?.viewModelScope?.cancel()
-        viewModel?.mapStateController?.shutdown()
         viewModel = null
         Dispatchers.resetMain()
     }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -41,9 +41,6 @@ import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class MapViewModelTest {
-    // Runs in desktopTest because MapCompose's MapState requires a working Compose runtime
-    // and snapshot system. Android JVM unit tests lack a Looper, causing snapshot coroutines
-    // to leak IllegalStateException via HandlerDispatcher when Dispatchers.Main is reset.
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var mapProvider: TileStreamProvider
@@ -83,7 +80,7 @@ class MapViewModelTest {
     @AfterTest
     fun tearDown() {
         viewModel?.viewModelScope?.cancel()
-        viewModel?.state?.shutdown()
+        viewModel?.mapStateController?.shutdown()
         viewModel = null
         Dispatchers.resetMain()
     }
@@ -99,6 +96,7 @@ class MapViewModelTest {
                 saveMapStateUseCase = saveMapStateUseCase,
                 loadSettingsUseCase = loadSettingsUseCase,
                 tileCacheStatsTracker = TileCacheStatsTracker(),
+                mapStateController = FakeMapStateController(),
             )
         viewModel = vm
         return vm


### PR DESCRIPTION
## Summary

- Introduces `MapStateController` interface + `MapComposeStateController` (wraps MapCompose's `MapState`) + `FakeMapStateController` (no-op for tests)
- `MapViewModel` now receives the controller via DI; `MapModule` provides `MapComposeStateController` in production
- Moves `MapViewModelTest` from `desktopTest` to `commonTest` — the 26 ViewModel tests now run on all platforms without requiring a Compose runtime

## Why

MapCompose's `MapState` creates snapshot coroutines internally that dispatch through `HandlerDispatcher`. On Android JVM unit tests, `Dispatchers.resetMain()` causes those coroutines to crash because `Looper.getMainLooper()` returns null. Moving the test to `desktopTest` was the short-term workaround; this PR fixes the root cause by decoupling `MapViewModel` from the concrete `MapState`.

## Test Plan

- [x] `./gradlew :composeApp:desktopTest` — 26 `MapViewModelTest` cases pass in `commonTest`
- [x] `./gradlew :composeApp:testReleaseUnitTest` — Android unit tests pass
- [x] `./gradlew :composeApp:compileReleaseKotlinAndroid` — Android compilation clean
- [ ] Smoke test map rendering on Android / Desktop to verify `MapComposeStateController` wiring

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)