### PR TITLE
Add offline region detail view

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -187,4 +187,10 @@
     <string name="offline_maps_delete_confirm_cancel">Cancel</string>
     <string name="offline_map_thumbnail">Map thumbnail</string>
     <string name="offline_map_thumbnail_placeholder">Map thumbnail placeholder</string>
+    <string name="offline_maps_detail_status">Status</string>
+    <string name="offline_maps_detail_zoom">Zoom levels</string>
+    <string name="offline_maps_detail_tile_count">Tile count</string>
+    <string name="offline_maps_detail_size">Size</string>
+    <string name="offline_maps_detail_provider">Tile provider</string>
+    <string name="offline_maps_detail_created">Created</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/extensions/TimeExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/extensions/TimeExtensions.kt
@@ -2,6 +2,7 @@ package com.jordankurtz.piawaremobile.extensions
 
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
@@ -21,3 +22,19 @@ val Instant.formattedTime: String
             }
         return formatter.format(localDateTime)
     }
+
+val Instant.formattedDate: String
+    get() = formattedDateInZone(TimeZone.currentSystemDefault())
+
+fun Instant.formattedDateInZone(timeZone: TimeZone): String {
+    val localDateTime = toLocalDateTime(timeZone)
+    val formatter =
+        LocalDateTime.Format {
+            year()
+            char('-')
+            monthNumber(padding = Padding.ZERO)
+            char('-')
+            day(padding = Padding.ZERO)
+        }
+    return formatter.format(localDateTime)
+}

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.settings.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -176,6 +177,7 @@ fun OfflineMapsScreen(
                     onDeleteRegion = onDeleteRegion,
                     onRetryRegion = onRetry,
                     onCancelRegion = onCancelDownload,
+                    onRegionClick = {},
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -208,6 +210,7 @@ private fun OfflineRegionList(
     onDeleteRegion: (OfflineRegion) -> Unit,
     onRetryRegion: (OfflineRegion) -> Unit,
     onCancelRegion: () -> Unit,
+    onRegionClick: (OfflineRegion) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
@@ -217,6 +220,7 @@ private fun OfflineRegionList(
                 onDelete = { onDeleteRegion(region) },
                 onRetry = { onRetryRegion(region) },
                 onCancel = onCancelRegion,
+                onClick = { onRegionClick(region) },
             )
             HorizontalDivider()
         }
@@ -229,12 +233,14 @@ internal fun OfflineRegionItem(
     onDelete: () -> Unit,
     onRetry: () -> Unit,
     onCancel: () -> Unit,
+    onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
+                .clickable(onClick = onClick)
                 .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -81,6 +81,7 @@ fun OfflineMapsScreen(
         viewportZoom: Int,
     ) -> Unit = { _, _, _, _, _ -> },
     onCancelDownload: () -> Unit = {},
+    onRegionClick: (OfflineRegion) -> Unit = {},
 ) {
     var showDownloadDialog by remember { mutableStateOf(false) }
     var showMapPicker by remember { mutableStateOf(false) }
@@ -88,6 +89,15 @@ fun OfflineMapsScreen(
     // Hoisted so the name survives round-trips to the map picker
     var pendingName by remember { mutableStateOf("") }
     var pendingViewportZoom by remember { mutableStateOf(0) }
+    var selectedRegion by remember { mutableStateOf<OfflineRegion?>(null) }
+
+    selectedRegion?.let { region ->
+        OfflineRegionDetailScreen(
+            region = region,
+            onBack = { selectedRegion = null },
+        )
+        return
+    }
 
     if (showMapPicker) {
         MapRegionPickerScreen(
@@ -177,7 +187,10 @@ fun OfflineMapsScreen(
                     onDeleteRegion = onDeleteRegion,
                     onRetryRegion = onRetry,
                     onCancelRegion = onCancelDownload,
-                    onRegionClick = {},
+                    onRegionClick = { region ->
+                        selectedRegion = region
+                        onRegionClick(region)
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
@@ -26,12 +26,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.jordankurtz.piawaremobile.extensions.formattedDate
 import com.jordankurtz.piawaremobile.map.MapViewModel
 import com.jordankurtz.piawaremobile.map.OpenStreetMap
 import com.jordankurtz.piawaremobile.map.doProjection
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -48,6 +47,7 @@ import piawaremobile.composeapp.generated.resources.offline_maps_detail_zoom
 import kotlin.time.Instant
 
 private const val DETAIL_BOUNDS_PATH_ID = "detail_bounds"
+private val BoundsPathColor = Color(0xFF2196F3)
 
 @Composable
 fun OfflineRegionDetailScreen(
@@ -62,7 +62,7 @@ fun OfflineRegionDetailScreen(
         mapViewModel.mapStateController.scrollTo(area = mapBounds, padding = Offset(0.15f, 0.15f))
         mapViewModel.mapStateController.addPath(
             id = DETAIL_BOUNDS_PATH_ID,
-            color = Color(0xFF2196F3),
+            color = BoundsPathColor,
             width = 2.dp,
         ) {
             addPoints(
@@ -154,7 +154,7 @@ internal fun OfflineRegionDetailContent(
                 )
                 DetailRow(
                     label = stringResource(Res.string.offline_maps_detail_created),
-                    value = formatEpochDate(region.createdAt),
+                    value = Instant.fromEpochMilliseconds(region.createdAt).formattedDate,
                 )
             }
         }
@@ -178,13 +178,4 @@ private fun DetailRow(
         Text(text = value, style = MaterialTheme.typography.bodyMedium)
     }
     HorizontalDivider()
-}
-
-private fun formatEpochDate(epochMillis: Long): String {
-    val local = Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(TimeZone.currentSystemDefault())
-    @Suppress("DEPRECATION")
-    return "${local.year}-${local.monthNumber.toString().padStart(
-        2,
-        '0',
-    )}-${local.dayOfMonth.toString().padStart(2, '0')}"
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
@@ -1,0 +1,190 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.jordankurtz.piawaremobile.map.MapViewModel
+import com.jordankurtz.piawaremobile.map.OpenStreetMap
+import com.jordankurtz.piawaremobile.map.doProjection
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import ovh.plrapps.mapcompose.api.BoundingBox
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.ic_arrow_back
+import piawaremobile.composeapp.generated.resources.navigate_back
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_created
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_provider
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_size
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_status
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_tile_count
+import piawaremobile.composeapp.generated.resources.offline_maps_detail_zoom
+import kotlin.time.Instant
+
+private const val DETAIL_BOUNDS_PATH_ID = "detail_bounds"
+
+@Composable
+fun OfflineRegionDetailScreen(
+    region: OfflineRegion,
+    onBack: () -> Unit,
+    mapViewModel: MapViewModel = koinViewModel(),
+) {
+    LaunchedEffect(region.id) {
+        val (xLeft, yTop) = doProjection(region.maxLat, region.minLon)
+        val (xRight, yBottom) = doProjection(region.minLat, region.maxLon)
+        val mapBounds = BoundingBox(xLeft = xLeft, yTop = yTop, xRight = xRight, yBottom = yBottom)
+        mapViewModel.mapStateController.scrollTo(area = mapBounds, padding = Offset(0.15f, 0.15f))
+        mapViewModel.mapStateController.addPath(
+            id = DETAIL_BOUNDS_PATH_ID,
+            color = Color(0xFF2196F3),
+            width = 2.dp,
+        ) {
+            addPoints(
+                listOf(
+                    Pair(xLeft, yTop),
+                    Pair(xRight, yTop),
+                    Pair(xRight, yBottom),
+                    Pair(xLeft, yBottom),
+                    Pair(xLeft, yTop),
+                ),
+            )
+        }
+    }
+    DisposableEffect(region.id) {
+        onDispose {
+            mapViewModel.mapStateController.removePath(DETAIL_BOUNDS_PATH_ID)
+        }
+    }
+    OfflineRegionDetailContent(
+        region = region,
+        mapLayer = {
+            OpenStreetMap(
+                state = mapViewModel.state,
+                modifier = Modifier.fillMaxSize(),
+            )
+        },
+        onBack = onBack,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun OfflineRegionDetailContent(
+    region: OfflineRegion,
+    mapLayer: @Composable () -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(region.name) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_arrow_back),
+                            contentDescription = stringResource(Res.string.navigate_back),
+                        )
+                    }
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+            )
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            Box(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+                mapLayer()
+            }
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp),
+            ) {
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_status),
+                    value = region.status.name.lowercase().replaceFirstChar { it.uppercase() },
+                )
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_zoom),
+                    value = "${region.minZoom} – ${region.maxZoom}",
+                )
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_tile_count),
+                    value = region.tileCount.toString(),
+                )
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_size),
+                    value = "${region.sizeBytes / (1024 * 1024)} MB",
+                )
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_provider),
+                    value = region.providerId,
+                )
+                DetailRow(
+                    label = stringResource(Res.string.offline_maps_detail_created),
+                    value = formatEpochDate(region.createdAt),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+    HorizontalDivider()
+}
+
+private fun formatEpochDate(epochMillis: Long): String {
+    val local = Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(TimeZone.currentSystemDefault())
+    @Suppress("DEPRECATION")
+    return "${local.year}-${local.monthNumber.toString().padStart(
+        2,
+        '0',
+    )}-${local.dayOfMonth.toString().padStart(2, '0')}"
+}

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/extensions/TimeExtensionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/extensions/TimeExtensionsTest.kt
@@ -1,6 +1,8 @@
 package com.jordankurtz.piawaremobile.extensions
 
+import kotlinx.datetime.TimeZone
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Instant
 
@@ -26,5 +28,19 @@ class TimeExtensionsTest {
     fun formattedTimeIsNotEmpty() {
         val instant = Instant.parse("2024-06-01T00:00:00Z")
         assertTrue(instant.formattedTime.isNotEmpty())
+    }
+
+    @Test
+    fun formattedDateProducesYYYYMMDD() {
+        val instant = Instant.parse("2023-11-14T12:00:00Z")
+        val formatted = instant.formattedDateInZone(TimeZone.UTC)
+        assertEquals("2023-11-14", formatted)
+    }
+
+    @Test
+    fun formattedDatePadsMonthAndDay() {
+        val instant = Instant.parse("2024-03-05T00:00:00Z")
+        val formatted = instant.formattedDateInZone(TimeZone.UTC)
+        assertEquals("2024-03-05", formatted)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreenTest.kt
@@ -3,6 +3,8 @@ package com.jordankurtz.piawaremobile.settings.ui
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import com.jordankurtz.piawaremobile.map.offline.DownloadStatus
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
@@ -10,6 +12,7 @@ import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
 import kotlin.io.path.createTempFile
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class OfflineMapsScreenTest {
@@ -75,5 +78,67 @@ class OfflineMapsScreenTest {
             onNodeWithContentDescription("Map thumbnail").assertIsDisplayed()
 
             tmpFile.delete()
+        }
+
+    @Test
+    fun clickingRegionItemInvokesOnClick() =
+        runComposeUiTest {
+            var clicked = false
+            val region =
+                OfflineRegion(
+                    id = 1L,
+                    name = "Clickable Region",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    minLat = 40.0,
+                    maxLat = 41.0,
+                    minLon = -75.0,
+                    maxLon = -74.0,
+                    providerId = "osm",
+                    createdAt = 0L,
+                    status = DownloadStatus.COMPLETE,
+                )
+            setContent {
+                OfflineRegionItem(
+                    region = region,
+                    onDelete = {},
+                    onRetry = {},
+                    onCancel = {},
+                    onClick = { clicked = true },
+                )
+            }
+            onNodeWithText("Clickable Region").performClick()
+            assertTrue(clicked)
+        }
+
+    @Test
+    fun deleteButtonDoesNotTriggerRowClick() =
+        runComposeUiTest {
+            var rowClicked = false
+            val region =
+                OfflineRegion(
+                    id = 2L,
+                    name = "Delete Test Region",
+                    minZoom = 8,
+                    maxZoom = 14,
+                    minLat = 40.0,
+                    maxLat = 41.0,
+                    minLon = -75.0,
+                    maxLon = -74.0,
+                    providerId = "osm",
+                    createdAt = 0L,
+                    status = DownloadStatus.COMPLETE,
+                )
+            setContent {
+                OfflineRegionItem(
+                    region = region,
+                    onDelete = {},
+                    onRetry = {},
+                    onCancel = {},
+                    onClick = { rowClicked = true },
+                )
+            }
+            onNodeWithContentDescription("Delete region").performClick()
+            assertTrue(!rowClicked)
         }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreenTest.kt
@@ -85,6 +85,15 @@ class OfflineRegionDetailScreenTest {
         }
 
     @Test
+    fun statusCompleteDisplayedAsComplete() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("Complete").assertIsDisplayed()
+        }
+
+    @Test
     fun backButtonInvokesCallback() =
         runComposeUiTest {
             var clicked = false

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreenTest.kt
@@ -1,0 +1,97 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.jordankurtz.piawaremobile.map.offline.DownloadStatus
+import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class OfflineRegionDetailScreenTest {
+    private val testRegion =
+        OfflineRegion(
+            id = 1L,
+            name = "Portland Downtown",
+            minZoom = 8,
+            maxZoom = 14,
+            minLat = 45.4,
+            maxLat = 45.6,
+            minLon = -122.7,
+            maxLon = -122.5,
+            providerId = "openstreetmap",
+            createdAt = 1700000000000L,
+            tileCount = 1234L,
+            sizeBytes = 18_874_368L,
+            status = DownloadStatus.COMPLETE,
+        )
+
+    @Test
+    fun regionNameShownInTopBar() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("Portland Downtown").assertIsDisplayed()
+        }
+
+    @Test
+    fun zoomRangeShown() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("8 – 14").assertIsDisplayed()
+        }
+
+    @Test
+    fun tileCountShown() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("1234").assertIsDisplayed()
+        }
+
+    @Test
+    fun sizeShown() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("18 MB").assertIsDisplayed()
+        }
+
+    @Test
+    fun providerShown() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("openstreetmap").assertIsDisplayed()
+        }
+
+    @Test
+    fun createdLabelShown() =
+        runComposeUiTest {
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = {})
+            }
+            onNodeWithText("Created").assertIsDisplayed()
+        }
+
+    @Test
+    fun backButtonInvokesCallback() =
+        runComposeUiTest {
+            var clicked = false
+            setContent {
+                OfflineRegionDetailContent(region = testRegion, mapLayer = {}, onBack = { clicked = true })
+            }
+            onNodeWithContentDescription("Back").performClick()
+            assertTrue(clicked)
+        }
+}


### PR DESCRIPTION
Closes #172

## Summary
- Tapping any region row in the offline maps list navigates to a full-screen detail view
- Detail view shows a live map (reusing the shared `MapViewModel`) locked to the region's bounding box, with a blue rectangle path overlay drawn via `addPath`/`DisposableEffect`
- Scrollable metadata section below the map: Status, Zoom levels, Tile count, Size, Tile provider, Created date

## Test Plan
- [ ] Desktop UI tests: `OfflineRegionDetailScreenTest` (8 tests — name, zoom, tile count, size, provider, created label, status, back button)
- [ ] Desktop UI tests: `OfflineMapsScreenTest` additions (click invokes callback, delete button does not trigger row click)
- [ ] Unit tests: `TimeExtensionsTest` additions (formattedDate produces correct YYYY-MM-DD output)
- [ ] ktlint, detekt, `desktopTest`, `testDebugUnitTest` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)