### PR TITLE
Add min, max, and default zoom level settings

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
@@ -67,4 +67,17 @@ class SettingsScreenAndroidTest {
         composeTestRule.onNode(hasText("Servers") and hasClickAction()).performClick()
         assertTrue(clicked)
     }
+
+    @Test
+    fun zoomSettingsLabelsAreDisplayed() {
+        composeTestRule.setContent {
+            MainScreen(onServersClicked = {}, viewModel = createViewModel())
+        }
+        composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText("Default Zoom"))
+        composeTestRule.onNodeWithText("Default Zoom").assertIsDisplayed()
+        composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText("Min Zoom"))
+        composeTestRule.onNodeWithText("Min Zoom").assertIsDisplayed()
+        composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText("Max Zoom"))
+        composeTestRule.onNodeWithText("Max Zoom").assertIsDisplayed()
+    }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlayTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlayTest.kt
@@ -16,7 +16,7 @@ class TileCacheDebugOverlayTest {
     fun overlayRendersWithTileStats() {
         val stats = TileCacheStats(diskHits = 10L, networkFetches = 5L, errors = 1L)
         composeTestRule.setContent {
-            TileCacheDebugOverlay(stats = stats)
+            TileCacheDebugOverlay(stats = stats, currentZoom = 12, zoomSettings = null)
         }
         composeTestRule.onNodeWithText("D:10", substring = true).assertExists()
         composeTestRule.onNodeWithText("N:5", substring = true).assertExists()

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -193,4 +193,7 @@
     <string name="offline_maps_detail_size">Size</string>
     <string name="offline_maps_detail_provider">Tile provider</string>
     <string name="offline_maps_detail_created">Created</string>
+    <string name="zoom_default_title">Default Zoom</string>
+    <string name="zoom_min_title">Min Zoom</string>
+    <string name="zoom_max_title">Max Zoom</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
@@ -112,7 +112,10 @@ class MapComposeStateController : MapStateController {
 
     override fun removePath(id: String) = mapState.removePath(id)
 
-    override fun setScaleLimits(minScale: Double, maxScale: Double) {
+    override fun setScaleLimits(
+        minScale: Double,
+        maxScale: Double,
+    ) {
         mapState.minimumScaleMode = Forced(minScale)
         mapState.maxScale = maxScale
     }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapComposeStateController.kt
@@ -12,6 +12,8 @@ import ovh.plrapps.mapcompose.api.BoundingBox
 import ovh.plrapps.mapcompose.api.addLayer
 import ovh.plrapps.mapcompose.api.addMarker
 import ovh.plrapps.mapcompose.api.addPath
+import ovh.plrapps.mapcompose.api.maxScale
+import ovh.plrapps.mapcompose.api.minimumScaleMode
 import ovh.plrapps.mapcompose.api.onMarkerClick
 import ovh.plrapps.mapcompose.api.onTap
 import ovh.plrapps.mapcompose.api.onTouchDown
@@ -109,6 +111,11 @@ class MapComposeStateController : MapStateController {
     }
 
     override fun removePath(id: String) = mapState.removePath(id)
+
+    override fun setScaleLimits(minScale: Double, maxScale: Double) {
+        mapState.minimumScaleMode = Forced(minScale)
+        mapState.maxScale = maxScale
+    }
 
     fun shutdown() = mapState.shutdown()
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapHelpers.kt
@@ -23,6 +23,8 @@ const val GROUND_ALTITUDE = "ground"
 
 fun scaleToOsmZoom(scale: Float): Int = (MAX_LEVEL + log2(scale.toDouble())).roundToInt().coerceIn(MIN_LEVEL, MAX_LEVEL)
 
+fun osmZoomToScale(zoom: Int): Double = 2.0.pow(zoom - MAX_LEVEL)
+
 fun mapSizeAtLevel(
     wmtsLevel: Int,
     tileSize: Int,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapScreen.kt
@@ -53,6 +53,8 @@ fun MapScreen(
     val isFollowingUser by mapViewModel.followingUserLocation.collectAsState()
     val showUserLocationOnMap by mapViewModel.showUserLocationOnMap.collectAsState()
     val tileStats by mapViewModel.tileStats.collectAsState()
+    val currentZoom by mapViewModel.currentZoomLevel.collectAsState()
+    val zoomSettings by mapViewModel.zoomSettings.collectAsState()
     val flightDetails by aircraftViewModel.flightDetails.collectAsState()
     val aircraftTrails by aircraftViewModel.aircraftTrails.collectAsState()
     val sheetState =
@@ -134,6 +136,8 @@ fun MapScreen(
         if (isDebugBuild) {
             TileCacheDebugOverlay(
                 stats = tileStats,
+                currentZoom = currentZoom,
+                zoomSettings = zoomSettings,
                 modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
@@ -14,6 +14,7 @@ import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
 
 data class MapScrollPosition(val scrollX: Double, val scrollY: Double, val scale: Double)
 
+@Suppress("TooManyFunctions")
 interface MapStateController {
     val scrollAndScaleFlow: Flow<MapScrollPosition>
 
@@ -37,7 +38,10 @@ interface MapStateController {
 
     var scale: Double
 
-    fun setScaleLimits(minScale: Double, maxScale: Double)
+    fun setScaleLimits(
+        minScale: Double,
+        maxScale: Double,
+    )
 
     suspend fun scrollTo(
         x: Double,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapStateController.kt
@@ -37,6 +37,8 @@ interface MapStateController {
 
     var scale: Double
 
+    fun setScaleLimits(minScale: Double, maxScale: Double)
+
     suspend fun scrollTo(
         x: Double,
         y: Double,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -29,11 +29,14 @@ import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -87,6 +90,14 @@ class MapViewModel(
     val showUserLocationOnMap: StateFlow<Boolean> = _showUserLocationOnMap
 
     val tileStats: StateFlow<TileCacheStats> = tileCacheStatsTracker.stats
+
+    val currentZoomLevel: StateFlow<Int> =
+        mapStateController.scrollAndScaleFlow
+            .map { scaleToOsmZoom(it.scale.toFloat()) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), MIN_LEVEL)
+
+    private val _zoomSettings = MutableStateFlow<Triple<Int, Int, Int>?>(null)
+    val zoomSettings: StateFlow<Triple<Int, Int, Int>?> = _zoomSettings
 
     /** Exposes the last location passed to [recenterOnLocation] for test verification. */
     internal val lastRecenteredLocation = MutableStateFlow<Location?>(null)
@@ -173,6 +184,7 @@ class MapViewModel(
 
     private suspend fun onSettingsLoaded(settings: Settings) {
         this.settings = settings
+        _zoomSettings.value = Triple(settings.minZoomLevel, settings.maxZoomLevel, settings.defaultZoomLevel)
         _showUserLocationOnMap.value = settings.showUserLocationOnMap
         if (!settings.showUserLocationOnMap) {
             _followingUserLocation.value = false

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jordankurtz.logger.Logger
-import com.jordankurtz.piawaremobile.map.osmZoomToScale
 import com.jordankurtz.piawaremobile.extensions.overlayColor
 import com.jordankurtz.piawaremobile.map.debug.TileCacheStats
 import com.jordankurtz.piawaremobile.map.debug.TileCacheStatsTracker
@@ -192,14 +191,18 @@ class MapViewModel(
         }
     }
 
-    private suspend fun loadMapState(minZoom: Int, maxZoom: Int) {
+    private suspend fun loadMapState(
+        minZoom: Int,
+        maxZoom: Int,
+    ) {
         val savedState = getSavedMapStateUseCase()
         Logger.d("Restored map state $savedState")
         mapStateController.setScroll(savedState.scrollX, savedState.scrollY)
-        mapStateController.scale = savedState.zoom.coerceIn(
-            osmZoomToScale(minZoom),
-            osmZoomToScale(maxZoom),
-        )
+        mapStateController.scale =
+            savedState.zoom.coerceIn(
+                osmZoomToScale(minZoom),
+                osmZoomToScale(maxZoom),
+            )
     }
 
     private fun startSaveMapStateJob() {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/MapViewModel.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jordankurtz.logger.Logger
+import com.jordankurtz.piawaremobile.map.osmZoomToScale
 import com.jordankurtz.piawaremobile.extensions.overlayColor
 import com.jordankurtz.piawaremobile.map.debug.TileCacheStats
 import com.jordankurtz.piawaremobile.map.debug.TileCacheStatsTracker
@@ -178,18 +179,27 @@ class MapViewModel(
             _followingUserLocation.value = false
         }
         onAircraftTrailsUpdated(lastTrails)
+        mapStateController.setScaleLimits(
+            osmZoomToScale(settings.minZoomLevel),
+            osmZoomToScale(settings.maxZoomLevel),
+        )
         saveStateJob?.cancel()
         if (settings.restoreMapStateOnStart) {
-            loadMapState()
+            loadMapState(settings.minZoomLevel, settings.maxZoomLevel)
             startSaveMapStateJob()
+        } else {
+            mapStateController.scale = osmZoomToScale(settings.defaultZoomLevel)
         }
     }
 
-    private suspend fun loadMapState() {
+    private suspend fun loadMapState(minZoom: Int, maxZoom: Int) {
         val savedState = getSavedMapStateUseCase()
         Logger.d("Restored map state $savedState")
         mapStateController.setScroll(savedState.scrollX, savedState.scrollY)
-        mapStateController.scale = savedState.zoom
+        mapStateController.scale = savedState.zoom.coerceIn(
+            osmZoomToScale(minZoom),
+            osmZoomToScale(maxZoom),
+        )
     }
 
     private fun startSaveMapStateJob() {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlay.kt
@@ -14,23 +14,30 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun TileCacheDebugOverlay(
     stats: TileCacheStats,
+    currentZoom: Int,
+    zoomSettings: Triple<Int, Int, Int>?,
     modifier: Modifier = Modifier,
 ) {
     val hitPct = (stats.hitRate * 100).toInt()
-    val label =
-        buildString {
-            append("Tiles  D:${stats.diskHits}  O:${stats.offlineHits}  N:${stats.networkFetches}")
-            if (stats.errors > 0) append("  E:${stats.errors}")
-            append("  $hitPct% cache")
+    val tilesLine = buildString {
+        append("Tiles  D:${stats.diskHits}  O:${stats.offlineHits}  N:${stats.networkFetches}")
+        if (stats.errors > 0) append("  E:${stats.errors}")
+        append("  $hitPct% cache")
+    }
+    val zoomLine = buildString {
+        append("Zoom $currentZoom")
+        if (zoomSettings != null) {
+            val (min, max, default) = zoomSettings
+            append("  (min:$min  max:$max  default:$default)")
         }
-    Text(
-        text = label,
+    }
+    androidx.compose.foundation.layout.Column(
         modifier =
             modifier
                 .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(4.dp))
                 .padding(horizontal = 6.dp, vertical = 3.dp),
-        color = Color.White,
-        fontSize = 11.sp,
-        fontFamily = FontFamily.Monospace,
-    )
+    ) {
+        Text(text = tilesLine, color = Color.White, fontSize = 11.sp, fontFamily = FontFamily.Monospace)
+        Text(text = zoomLine, color = Color.White, fontSize = 11.sp, fontFamily = FontFamily.Monospace)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlay.kt
@@ -19,18 +19,20 @@ fun TileCacheDebugOverlay(
     modifier: Modifier = Modifier,
 ) {
     val hitPct = (stats.hitRate * 100).toInt()
-    val tilesLine = buildString {
-        append("Tiles  D:${stats.diskHits}  O:${stats.offlineHits}  N:${stats.networkFetches}")
-        if (stats.errors > 0) append("  E:${stats.errors}")
-        append("  $hitPct% cache")
-    }
-    val zoomLine = buildString {
-        append("Zoom $currentZoom")
-        if (zoomSettings != null) {
-            val (min, max, default) = zoomSettings
-            append("  (min:$min  max:$max  default:$default)")
+    val tilesLine =
+        buildString {
+            append("Tiles  D:${stats.diskHits}  O:${stats.offlineHits}  N:${stats.networkFetches}")
+            if (stats.errors > 0) append("  E:${stats.errors}")
+            append("  $hitPct% cache")
         }
-    }
+    val zoomLine =
+        buildString {
+            append("Zoom $currentZoom")
+            if (zoomSettings != null) {
+                val (min, max, default) = zoomSettings
+                append("  (min:$min  max:$max  default:$default)")
+            }
+        }
     androidx.compose.foundation.layout.Column(
         modifier =
             modifier

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/Settings.kt
@@ -16,4 +16,7 @@ data class Settings(
     val enableFlightAwareApi: Boolean = false,
     val flightAwareApiKey: String = "",
     val mapProviderId: String = TileProviders.OPENSTREETMAP.id,
+    val defaultZoomLevel: Int = SettingsRepository.DEFAULT_ZOOM_LEVEL,
+    val minZoomLevel: Int = SettingsRepository.MIN_ZOOM_LEVEL,
+    val maxZoomLevel: Int = SettingsRepository.MAX_ZOOM_LEVEL,
 )

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -91,4 +91,19 @@ class SettingsViewModel(
         viewModelScope.launch {
             settingsService.setMapProviderId(config.id)
         }
+
+    fun updateDefaultZoomLevel(zoom: Int) =
+        viewModelScope.launch {
+            settingsService.setDefaultZoomLevel(zoom)
+        }
+
+    fun updateMinZoomLevel(zoom: Int) =
+        viewModelScope.launch {
+            settingsService.setMinZoomLevel(zoom)
+        }
+
+    fun updateMaxZoomLevel(zoom: Int) =
+        viewModelScope.launch {
+            settingsService.setMaxZoomLevel(zoom)
+        }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.Factory
 import kotlin.uuid.Uuid
 
+@Suppress("TooManyFunctions")
 @Factory
 class SettingsViewModel(
     private val settingsService: SettingsService,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepository.kt
@@ -29,6 +29,12 @@ interface SettingsRepository {
         val ENABLE_FLIGHT_AWARE_API = booleanPreferencesKey("enableFlightAwareApi")
         val FLIGHT_AWARE_API_KEY = stringPreferencesKey("flightAwareApiKey")
         val MAP_PROVIDER_ID = stringPreferencesKey("mapProviderId")
+        val DEFAULT_ZOOM_LEVEL_KEY = intPreferencesKey("defaultZoomLevel")
+        val MIN_ZOOM_LEVEL_KEY = intPreferencesKey("minZoomLevel")
+        val MAX_ZOOM_LEVEL_KEY = intPreferencesKey("maxZoomLevel")
         const val DEFAULT_REFRESH_INTERVAL = 5
+        const val DEFAULT_ZOOM_LEVEL = 8
+        const val MIN_ZOOM_LEVEL = 1
+        const val MAX_ZOOM_LEVEL = 16
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
@@ -39,6 +39,9 @@ class SettingsRepositoryImpl(
                 enableFlightAwareApi = preferences[SettingsRepository.ENABLE_FLIGHT_AWARE_API] ?: false,
                 flightAwareApiKey = preferences[SettingsRepository.FLIGHT_AWARE_API_KEY] ?: "",
                 mapProviderId = preferences[SettingsRepository.MAP_PROVIDER_ID] ?: TileProviders.OPENSTREETMAP.id,
+                defaultZoomLevel = preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL_KEY] ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
+                minZoomLevel = preferences[SettingsRepository.MIN_ZOOM_LEVEL_KEY] ?: SettingsRepository.MIN_ZOOM_LEVEL,
+                maxZoomLevel = preferences[SettingsRepository.MAX_ZOOM_LEVEL_KEY] ?: SettingsRepository.MAX_ZOOM_LEVEL,
             )
         }
     }
@@ -57,6 +60,9 @@ class SettingsRepositoryImpl(
             preferences[SettingsRepository.ENABLE_FLIGHT_AWARE_API] = settings.enableFlightAwareApi
             preferences[SettingsRepository.FLIGHT_AWARE_API_KEY] = settings.flightAwareApiKey
             preferences[SettingsRepository.MAP_PROVIDER_ID] = settings.mapProviderId
+            preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL_KEY] = settings.defaultZoomLevel
+            preferences[SettingsRepository.MIN_ZOOM_LEVEL_KEY] = settings.minZoomLevel
+            preferences[SettingsRepository.MAX_ZOOM_LEVEL_KEY] = settings.maxZoomLevel
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/repo/SettingsRepositoryImpl.kt
@@ -39,9 +39,15 @@ class SettingsRepositoryImpl(
                 enableFlightAwareApi = preferences[SettingsRepository.ENABLE_FLIGHT_AWARE_API] ?: false,
                 flightAwareApiKey = preferences[SettingsRepository.FLIGHT_AWARE_API_KEY] ?: "",
                 mapProviderId = preferences[SettingsRepository.MAP_PROVIDER_ID] ?: TileProviders.OPENSTREETMAP.id,
-                defaultZoomLevel = preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL_KEY] ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
-                minZoomLevel = preferences[SettingsRepository.MIN_ZOOM_LEVEL_KEY] ?: SettingsRepository.MIN_ZOOM_LEVEL,
-                maxZoomLevel = preferences[SettingsRepository.MAX_ZOOM_LEVEL_KEY] ?: SettingsRepository.MAX_ZOOM_LEVEL,
+                defaultZoomLevel =
+                    preferences[SettingsRepository.DEFAULT_ZOOM_LEVEL_KEY]
+                        ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
+                minZoomLevel =
+                    preferences[SettingsRepository.MIN_ZOOM_LEVEL_KEY]
+                        ?: SettingsRepository.MIN_ZOOM_LEVEL,
+                maxZoomLevel =
+                    preferences[SettingsRepository.MAX_ZOOM_LEVEL_KEY]
+                        ?: SettingsRepository.MAX_ZOOM_LEVEL,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
@@ -72,6 +72,9 @@ import piawaremobile.composeapp.generated.resources.show_user_location_descripti
 import piawaremobile.composeapp.generated.resources.show_user_location_title
 import piawaremobile.composeapp.generated.resources.trail_display_mode_description
 import piawaremobile.composeapp.generated.resources.trail_display_mode_title
+import piawaremobile.composeapp.generated.resources.zoom_default_title
+import piawaremobile.composeapp.generated.resources.zoom_max_title
+import piawaremobile.composeapp.generated.resources.zoom_min_title
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -169,6 +172,33 @@ fun MainScreen(
                     description = stringResource(Res.string.show_user_location_description),
                     checked = settings.getValue()?.showUserLocationOnMap ?: true,
                     onCheckedChange = viewModel::updateShowUserLocationOnMap,
+                )
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.zoom_default_title),
+                    value = settings.getValue()?.defaultZoomLevel ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateDefaultZoomLevel,
+                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
+                )
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.zoom_min_title),
+                    value = settings.getValue()?.minZoomLevel ?: SettingsRepository.MIN_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateMinZoomLevel,
+                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
+                )
+            }
+
+            item {
+                SettingsNumberInput(
+                    title = stringResource(Res.string.zoom_max_title),
+                    value = settings.getValue()?.maxZoomLevel ?: SettingsRepository.MAX_ZOOM_LEVEL,
+                    onValueChange = viewModel::updateMaxZoomLevel,
+                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
                 )
             }
 
@@ -361,9 +391,11 @@ fun SettingsNumberInput(
     value: Int,
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    range: IntRange? = null,
 ) {
     var textValue by remember { mutableStateOf(value.toString()) }
-    val isValid = textValue.toIntOrNull() != null
+    val parsedValue = textValue.toIntOrNull()
+    val isValid = parsedValue != null && (range == null || parsedValue in range)
 
     LaunchedEffect(value) {
         if (textValue.toIntOrNull() != value) {
@@ -390,7 +422,9 @@ fun SettingsNumberInput(
                 value = textValue,
                 onValueChange = {
                     textValue = it
-                    it.toIntOrNull()?.let(onValueChange)
+                    it.toIntOrNull()?.let { v ->
+                        if (range == null || v in range) onValueChange(v)
+                    }
                 },
                 singleLine = true,
                 modifier =

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
@@ -47,4 +47,10 @@ interface SettingsService {
     suspend fun setFlightAwareApiKey(apiKey: String)
 
     suspend fun setMapProviderId(providerId: String)
+
+    suspend fun setDefaultZoomLevel(zoom: Int)
+
+    suspend fun setMinZoomLevel(zoom: Int)
+
+    suspend fun setMaxZoomLevel(zoom: Int)
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
@@ -115,4 +115,10 @@ class SettingsServiceImpl(
     override suspend fun setFlightAwareApiKey(apiKey: String) = updateSetting { it.copy(flightAwareApiKey = apiKey) }
 
     override suspend fun setMapProviderId(providerId: String) = updateSetting { it.copy(mapProviderId = providerId) }
+
+    override suspend fun setDefaultZoomLevel(zoom: Int) = updateSetting { it.copy(defaultZoomLevel = zoom) }
+
+    override suspend fun setMinZoomLevel(zoom: Int) = updateSetting { it.copy(minZoomLevel = zoom) }
+
+    override suspend fun setMaxZoomLevel(zoom: Int) = updateSetting { it.copy(maxZoomLevel = zoom) }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/MapWithListLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/MapWithListLayout.kt
@@ -48,6 +48,8 @@ fun MapWithListLayout(
     val receiverLocations by aircraftViewModel.receiverLocations.collectAsState()
     val numberOfPlanes by aircraftViewModel.numberOfPlanes.collectAsState()
     val tileStats by mapViewModel.tileStats.collectAsState()
+    val currentZoom by mapViewModel.currentZoomLevel.collectAsState()
+    val zoomSettings by mapViewModel.zoomSettings.collectAsState()
     val aircraftTrails by aircraftViewModel.aircraftTrails.collectAsState()
     val mapSelectedHex by mapViewModel.selectedAircraft.collectAsState()
     val activeProvider by mapViewModel.activeProvider.collectAsState()
@@ -113,6 +115,8 @@ fun MapWithListLayout(
             if (isDebugBuild) {
                 TileCacheDebugOverlay(
                     stats = tileStats,
+                    currentZoom = currentZoom,
+                    zoomSettings = zoomSettings,
                     modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
                 )
             }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
@@ -34,6 +34,14 @@ class FakeMapStateController : MapStateController {
 
     override var scale: Double = 1.0
 
+    var lastMinScale: Double = 0.0
+    var lastMaxScale: Double = Double.MAX_VALUE
+
+    override fun setScaleLimits(minScale: Double, maxScale: Double) {
+        lastMinScale = minScale
+        lastMaxScale = maxScale
+    }
+
     override suspend fun scrollTo(
         x: Double,
         y: Double,

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/FakeMapStateController.kt
@@ -37,7 +37,10 @@ class FakeMapStateController : MapStateController {
     var lastMinScale: Double = 0.0
     var lastMaxScale: Double = Double.MAX_VALUE
 
-    override fun setScaleLimits(minScale: Double, maxScale: Double) {
+    override fun setScaleLimits(
+        minScale: Double,
+        maxScale: Double,
+    ) {
         lastMinScale = minScale
         lastMaxScale = maxScale
     }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapHelpersTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapHelpersTest.kt
@@ -211,4 +211,30 @@ class MapHelpersTest {
         // scale ≈ 1e-6 → log2 ≈ -19.9 → well below MIN_LEVEL, clamped to 1
         assertEquals(MIN_LEVEL, scaleToOsmZoom(1e-6f))
     }
+
+    // --- osmZoomToScale tests ---
+
+    @Test
+    fun osmZoomToScaleMaxLevel() {
+        assertEquals(1.0, osmZoomToScale(MAX_LEVEL), 0.0001)
+    }
+
+    @Test
+    fun osmZoomToScaleMinLevel() {
+        // zoom 1: 2^(1-16) = 2^-15
+        assertEquals(1.0 / 32768.0, osmZoomToScale(MIN_LEVEL), 0.0001)
+    }
+
+    @Test
+    fun osmZoomToScaleMidLevel() {
+        // zoom 8: 2^(8-16) = 2^-8 = 1/256
+        assertEquals(1.0 / 256.0, osmZoomToScale(8), 0.0001)
+    }
+
+    @Test
+    fun osmZoomToScaleRoundTrip() {
+        for (zoom in MIN_LEVEL..MAX_LEVEL) {
+            assertEquals(zoom, scaleToOsmZoom(osmZoomToScale(zoom).toFloat()), "Round-trip failed for zoom $zoom")
+        }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -17,6 +17,7 @@ import com.jordankurtz.piawaremobile.settings.TrailDisplayMode
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
 import com.jordankurtz.piawaremobile.testutil.mockAircraft
 import com.jordankurtz.piawaremobile.testutil.mockServer
+import com.jordankurtz.piawaremobile.map.osmZoomToScale
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -86,6 +87,7 @@ class MapViewModelTest {
 
     private fun createViewModel(
         providerConfigFlow: MutableStateFlow<TileProviderConfig> = MutableStateFlow(TileProviders.OPENSTREETMAP),
+        mapStateController: FakeMapStateController = FakeMapStateController(),
     ): MapViewModel {
         val vm =
             MapViewModel(
@@ -95,7 +97,7 @@ class MapViewModelTest {
                 saveMapStateUseCase = saveMapStateUseCase,
                 loadSettingsUseCase = loadSettingsUseCase,
                 tileCacheStatsTracker = TileCacheStatsTracker(),
-                mapStateController = FakeMapStateController(),
+                mapStateController = mapStateController,
             )
         viewModel = vm
         return vm
@@ -506,5 +508,54 @@ class MapViewModelTest {
                 )
             vm.onAircraftTrailsUpdated(trails)
             advanceUntilIdle()
+        }
+
+    @Test
+    fun `scale limits are set from settings on load`() =
+        runTest {
+            settingsFlow.value = Async.Success(settings.copy(minZoomLevel = 5, maxZoomLevel = 12))
+            val controller = FakeMapStateController()
+            createViewModel(mapStateController = controller)
+            advanceUntilIdle()
+            assertEquals(osmZoomToScale(5), controller.lastMinScale, 0.0001)
+            assertEquals(osmZoomToScale(12), controller.lastMaxScale, 0.0001)
+        }
+
+    @Test
+    fun `default zoom applied when restoreMapStateOnStart is false`() =
+        runTest {
+            settingsFlow.value = Async.Success(settings.copy(defaultZoomLevel = 10, restoreMapStateOnStart = false))
+            val controller = FakeMapStateController()
+            createViewModel(mapStateController = controller)
+            advanceUntilIdle()
+            assertEquals(osmZoomToScale(10), controller.scale, 0.0001)
+        }
+
+    @Test
+    fun `restored zoom below min is clamped up to min`() =
+        runTest {
+            settingsFlow.value = Async.Success(
+                settings.copy(minZoomLevel = 8, maxZoomLevel = 14, restoreMapStateOnStart = true),
+            )
+            everySuspend { getSavedMapStateUseCase.invoke() } returns
+                com.jordankurtz.piawaremobile.model.MapState(0.5, 0.5, osmZoomToScale(3))
+            val controller = FakeMapStateController()
+            createViewModel(mapStateController = controller)
+            advanceUntilIdle()
+            assertEquals(osmZoomToScale(8), controller.scale, 0.0001)
+        }
+
+    @Test
+    fun `restored zoom above max is clamped down to max`() =
+        runTest {
+            settingsFlow.value = Async.Success(
+                settings.copy(minZoomLevel = 5, maxZoomLevel = 10, restoreMapStateOnStart = true),
+            )
+            everySuspend { getSavedMapStateUseCase.invoke() } returns
+                com.jordankurtz.piawaremobile.model.MapState(0.5, 0.5, osmZoomToScale(15))
+            val controller = FakeMapStateController()
+            createViewModel(mapStateController = controller)
+            advanceUntilIdle()
+            assertEquals(osmZoomToScale(10), controller.scale, 0.0001)
         }
 }

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/MapViewModelTest.kt
@@ -17,7 +17,6 @@ import com.jordankurtz.piawaremobile.settings.TrailDisplayMode
 import com.jordankurtz.piawaremobile.settings.usecase.LoadSettingsUseCase
 import com.jordankurtz.piawaremobile.testutil.mockAircraft
 import com.jordankurtz.piawaremobile.testutil.mockServer
-import com.jordankurtz.piawaremobile.map.osmZoomToScale
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -534,9 +533,10 @@ class MapViewModelTest {
     @Test
     fun `restored zoom below min is clamped up to min`() =
         runTest {
-            settingsFlow.value = Async.Success(
-                settings.copy(minZoomLevel = 8, maxZoomLevel = 14, restoreMapStateOnStart = true),
-            )
+            settingsFlow.value =
+                Async.Success(
+                    settings.copy(minZoomLevel = 8, maxZoomLevel = 14, restoreMapStateOnStart = true),
+                )
             everySuspend { getSavedMapStateUseCase.invoke() } returns
                 com.jordankurtz.piawaremobile.model.MapState(0.5, 0.5, osmZoomToScale(3))
             val controller = FakeMapStateController()
@@ -548,9 +548,10 @@ class MapViewModelTest {
     @Test
     fun `restored zoom above max is clamped down to max`() =
         runTest {
-            settingsFlow.value = Async.Success(
-                settings.copy(minZoomLevel = 5, maxZoomLevel = 10, restoreMapStateOnStart = true),
-            )
+            settingsFlow.value =
+                Async.Success(
+                    settings.copy(minZoomLevel = 5, maxZoomLevel = 10, restoreMapStateOnStart = true),
+                )
             everySuspend { getSavedMapStateUseCase.invoke() } returns
                 com.jordankurtz.piawaremobile.model.MapState(0.5, 0.5, osmZoomToScale(15))
             val controller = FakeMapStateController()

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/map/debug/TileCacheDebugOverlayTest.kt
@@ -14,6 +14,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(diskHits = 42L, networkFetches = 8L),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("Tiles  D:42  O:0  N:8  84% cache", substring = false)
@@ -26,6 +28,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(diskHits = 3L, networkFetches = 7L),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("30% cache", substring = true)
@@ -38,6 +42,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(diskHits = 5L, networkFetches = 3L, errors = 2L),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("E:2", substring = true)
@@ -50,6 +56,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(diskHits = 5L, networkFetches = 3L, errors = 0L),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("Tiles  D:5  O:0  N:3  62% cache", substring = false)
@@ -62,6 +70,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("Tiles  D:0  O:0  N:0  0% cache", substring = false)
@@ -74,6 +84,8 @@ class TileCacheDebugOverlayTest {
             setContent {
                 TileCacheDebugOverlay(
                     stats = TileCacheStats(diskHits = 10L, offlineHits = 5L, networkFetches = 3L),
+                    currentZoom = 12,
+                    zoomSettings = null,
                 )
             }
             onNodeWithText("O:5", substring = true).assertIsDisplayed()

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreenTest.kt
@@ -44,4 +44,29 @@ class MainScreenTest {
 
             onNodeWithText("ESRI Satellite").assertIsDisplayed()
         }
+
+    @Test
+    fun zoomDefaultInputIsDisplayed() =
+        runComposeUiTest {
+            setContent {
+                SettingsNumberInput(title = "Default Zoom", value = 8, onValueChange = {}, range = 1..16)
+            }
+            onNodeWithText("Default Zoom").assertIsDisplayed()
+        }
+
+    @Test
+    fun zoomInputOutOfRangeDoesNotFireCallback() =
+        runComposeUiTest {
+            var fired = false
+            setContent {
+                SettingsNumberInput(
+                    title = "Min Zoom",
+                    value = 1,
+                    onValueChange = { fired = true },
+                    range = 1..16,
+                )
+            }
+            onNodeWithText("Min Zoom").assertIsDisplayed()
+            assert(!fired)
+        }
 }

--- a/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/jordankurtz/piawaremobile/ui/SettingsScreenTest.kt
@@ -48,6 +48,7 @@ class SettingsScreenTest {
                 MainScreen(onServersClicked = {}, viewModel = createViewModel())
             }
             // "Servers" appears as a section header and as a clickable item
+            onNode(hasScrollAction()).performScrollToNode(hasText("Servers"))
             onAllNodesWithText("Servers")[0].assertIsDisplayed()
         }
 
@@ -131,6 +132,7 @@ class SettingsScreenTest {
             setContent {
                 MainScreen(onServersClicked = {}, viewModel = createViewModel())
             }
+            onNode(hasScrollAction()).performScrollToNode(hasText("Offline Maps"))
             onNodeWithText("Offline Maps").assertIsDisplayed()
         }
 
@@ -145,6 +147,7 @@ class SettingsScreenTest {
                     viewModel = createViewModel(),
                 )
             }
+            onNode(hasScrollAction()).performScrollToNode(hasText("Offline Maps"))
             onNodeWithText("Offline Maps").performClick()
             assertTrue(clicked)
         }


### PR DESCRIPTION
Closes #5

## Summary
- Adds Default Zoom, Min Zoom, and Max Zoom integer input fields to the Settings screen, validated against the 1–16 OSM zoom range
- Persists all three values to DataStore and exposes them through the settings service and `SettingsViewModel`
- Enforces min/max limits at runtime via `MapState.minimumScaleMode` and `MapState.maxScale` — limits are applied natively by MapCompose on every pinch gesture, not just at startup
- Uses the default zoom level on first launch (or when "Restore map position" is off); clamps restored zoom into the min–max range on subsequent launches

## Test Plan
- [ ] Unit: `osmZoomToScale` round-trips correctly against existing `scaleToOsmZoom`
- [ ] Unit: `MapViewModel` applies scale limits from settings, defaults to `defaultZoomLevel`, and clamps restored zoom to min/max range
- [ ] Desktop UI: zoom inputs are displayed; out-of-range values do not fire the callback
- [ ] Android: zoom setting labels are visible on device/emulator
- [ ] Manual: pinch-zoom on map respects min/max limits from settings; app launches at the default zoom
- [ ] CI: full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)