### PR TITLE
Add API key edit/remove to map providers screen

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="map_providers_thunderforest_key_info">Get a free key at thunderforest.com</string>
     <string name="map_providers_jawg_key_info">Get a free key at jawg.io</string>
     <string name="map_providers_generic_key_info">Enter your API key for this provider</string>
+    <string name="map_providers_edit_api_key">Edit API key</string>
+    <string name="map_providers_remove_api_key">Remove key</string>
     <string name="clear_map_cache_title">Clear map cache</string>
     <string name="clear_map_cache_description">Delete cached tiles (offline maps are kept)</string>
     <string name="clear_map_cache_confirm_title">Clear map cache?</string>

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/MapModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/di/modules/MapModule.kt
@@ -1,19 +1,16 @@
 package com.jordankurtz.piawaremobile.di.modules
 
-import com.jordankurtz.piawaremobile.di.annotations.IODispatcher
 import com.jordankurtz.piawaremobile.map.MapLibreStateController
 import com.jordankurtz.piawaremobile.map.MapStateController
 import com.jordankurtz.piawaremobile.map.TileProviderConfig
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.map.resolveActiveProviderConfig
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.runBlocking
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -24,16 +21,14 @@ class MapModule {
     fun provideActiveTileProviderConfigFlow(
         settingsRepository: SettingsRepository,
         applicationScope: CoroutineScope,
-        @IODispatcher ioDispatcher: CoroutineDispatcher,
-    ): StateFlow<TileProviderConfig> {
-        val initial =
-            runBlocking(ioDispatcher) {
-                resolveActiveProviderConfig(settingsRepository.getSettings().first())
-            }
-        return settingsRepository.getSettings()
+    ): StateFlow<TileProviderConfig> =
+        settingsRepository.getSettings()
             .map { resolveActiveProviderConfig(it) }
-            .stateIn(scope = applicationScope, started = SharingStarted.Eagerly, initialValue = initial)
-    }
+            .stateIn(
+                scope = applicationScope,
+                started = SharingStarted.Eagerly,
+                initialValue = TileProviders.DEFAULT,
+            )
 
     @Factory
     fun provideMapStateController(): MapStateController = MapLibreStateController()

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolution.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolution.kt
@@ -10,8 +10,9 @@ fun resolveActiveProviderConfig(
     val allProviders = builtIns + settings.customProviders.map { it.toTileProviderConfig() }
     val config = allProviders.find { it.id == settings.mapProviderId } ?: TileProviders.DEFAULT
     return if (config.requiresApiKey) {
-        val key = settings.apiKeys[config.apiKeyGroup ?: config.id]?.takeIf { it.isNotBlank() }
-            ?: return TileProviders.DEFAULT
+        val key =
+            settings.apiKeys[config.apiKeyGroup ?: config.id]?.takeIf { it.isNotBlank() }
+                ?: return TileProviders.DEFAULT
         config.copy(styleUrl = config.resolvedStyleUrl(key))
     } else {
         config

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolution.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolution.kt
@@ -10,7 +10,8 @@ fun resolveActiveProviderConfig(
     val allProviders = builtIns + settings.customProviders.map { it.toTileProviderConfig() }
     val config = allProviders.find { it.id == settings.mapProviderId } ?: TileProviders.DEFAULT
     return if (config.requiresApiKey) {
-        val key = settings.apiKeys[config.apiKeyGroup ?: config.id] ?: ""
+        val key = settings.apiKeys[config.apiKeyGroup ?: config.id]?.takeIf { it.isNotBlank() }
+            ?: return TileProviders.DEFAULT
         config.copy(styleUrl = config.resolvedStyleUrl(key))
     } else {
         config

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -117,6 +117,10 @@ class SettingsViewModel(
         settingsService.setApiKey(providerId, key)
     }
 
+    fun removeApiKey(keyGroup: String) = viewModelScope.launch {
+        settingsService.removeApiKey(keyGroup)
+    }
+
     fun setApiKeyAndActivateProvider(
         keyGroup: String,
         key: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/SettingsViewModel.kt
@@ -117,9 +117,10 @@ class SettingsViewModel(
         settingsService.setApiKey(providerId, key)
     }
 
-    fun removeApiKey(keyGroup: String) = viewModelScope.launch {
-        settingsService.removeApiKey(keyGroup)
-    }
+    fun removeApiKey(keyGroup: String) =
+        viewModelScope.launch {
+            settingsService.removeApiKey(keyGroup)
+        }
 
     fun setApiKeyAndActivateProvider(
         keyGroup: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
@@ -117,7 +117,7 @@ fun MapProvidersScreen(
                 ApiKeyProviderRow(
                     config = config,
                     isSelected = config.id == activeProviderId,
-                    hasKey = apiKeys.containsKey(keyLookup),
+                    hasKey = apiKeys[keyLookup]?.isNotBlank() == true,
                     onClick = {
                         if (apiKeys.containsKey(keyLookup)) {
                             viewModel.updateMapProvider(config)

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
@@ -45,6 +45,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.ic_arrow_back
+import piawaremobile.composeapp.generated.resources.ic_edit
 import piawaremobile.composeapp.generated.resources.map_providers_add_custom
 import piawaremobile.composeapp.generated.resources.map_providers_api_key_configured
 import piawaremobile.composeapp.generated.resources.map_providers_api_key_hint
@@ -53,7 +54,9 @@ import piawaremobile.composeapp.generated.resources.map_providers_cancel
 import piawaremobile.composeapp.generated.resources.map_providers_custom_name_hint
 import piawaremobile.composeapp.generated.resources.map_providers_custom_url_hint
 import piawaremobile.composeapp.generated.resources.map_providers_delete_custom
+import piawaremobile.composeapp.generated.resources.map_providers_edit_api_key
 import piawaremobile.composeapp.generated.resources.map_providers_generic_key_info
+import piawaremobile.composeapp.generated.resources.map_providers_remove_api_key
 import piawaremobile.composeapp.generated.resources.map_providers_save
 import piawaremobile.composeapp.generated.resources.map_providers_stadia_key_info
 import piawaremobile.composeapp.generated.resources.map_providers_title
@@ -73,6 +76,7 @@ fun MapProvidersScreen(
     val customProviders = settings?.customProviders ?: emptyList()
 
     var pendingApiKeyProvider by remember { mutableStateOf<TileProviderConfig?>(null) }
+    var editKeyProvider by remember { mutableStateOf<TileProviderConfig?>(null) }
     var showAddCustom by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -121,6 +125,7 @@ fun MapProvidersScreen(
                             pendingApiKeyProvider = config
                         }
                     },
+                    onEditKey = { editKeyProvider = config },
                 )
             }
 
@@ -149,17 +154,8 @@ fun MapProvidersScreen(
 
     pendingApiKeyProvider?.let { provider ->
         val keyGroup = provider.apiKeyGroup ?: provider.id
-        val providerName =
-            when (provider.apiKeyGroup) {
-                "stadia" -> "Stadia Maps"
-                "maptiler" -> "MapTiler"
-                else -> provider.displayNameRes?.let { stringResource(it) } ?: provider.displayName
-            }
-        val keyInfo =
-            when (provider.apiKeyGroup) {
-                "stadia" -> stringResource(Res.string.map_providers_stadia_key_info)
-                else -> stringResource(Res.string.map_providers_generic_key_info)
-            }
+        val providerName = providerDisplayName(provider)
+        val keyInfo = providerKeyInfo(provider)
         ApiKeyBottomSheet(
             providerName = providerName,
             keyInfo = keyInfo,
@@ -168,6 +164,25 @@ fun MapProvidersScreen(
                 pendingApiKeyProvider = null
             },
             onDismiss = { pendingApiKeyProvider = null },
+        )
+    }
+
+    editKeyProvider?.let { provider ->
+        val keyGroup = provider.apiKeyGroup ?: provider.id
+        val providerName = providerDisplayName(provider)
+        val keyInfo = providerKeyInfo(provider)
+        ApiKeyBottomSheet(
+            providerName = providerName,
+            keyInfo = keyInfo,
+            onSave = { key ->
+                viewModel.updateApiKey(keyGroup, key)
+                editKeyProvider = null
+            },
+            onRemove = {
+                viewModel.removeApiKey(keyGroup)
+                editKeyProvider = null
+            },
+            onDismiss = { editKeyProvider = null },
         )
     }
 
@@ -181,6 +196,21 @@ fun MapProvidersScreen(
         )
     }
 }
+
+@Composable
+private fun providerDisplayName(provider: TileProviderConfig): String =
+    when (provider.apiKeyGroup) {
+        "stadia" -> "Stadia Maps"
+        "maptiler" -> "MapTiler"
+        else -> provider.displayNameRes?.let { stringResource(it) } ?: provider.displayName
+    }
+
+@Composable
+private fun providerKeyInfo(provider: TileProviderConfig): String =
+    when (provider.apiKeyGroup) {
+        "stadia" -> stringResource(Res.string.map_providers_stadia_key_info)
+        else -> stringResource(Res.string.map_providers_generic_key_info)
+    }
 
 @Composable
 fun BuiltInProviderRow(
@@ -220,6 +250,7 @@ fun ApiKeyProviderRow(
     isSelected: Boolean,
     hasKey: Boolean,
     onClick: () -> Unit,
+    onEditKey: (() -> Unit)? = null,
 ) {
     Column {
         Row(
@@ -227,7 +258,7 @@ fun ApiKeyProviderRow(
                 Modifier
                     .fillMaxWidth()
                     .clickable(onClick = onClick)
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                    .padding(start = 16.dp, end = 4.dp, top = 14.dp, bottom = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -242,6 +273,15 @@ fun ApiKeyProviderRow(
                         text = stringResource(Res.string.map_providers_api_key_configured),
                         style = MaterialTheme.typography.labelSmall,
                     )
+                }
+                if (onEditKey != null) {
+                    IconButton(onClick = onEditKey) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_edit),
+                            contentDescription = stringResource(Res.string.map_providers_edit_api_key),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             } else {
                 Badge(containerColor = MaterialTheme.colorScheme.errorContainer) {
@@ -336,6 +376,7 @@ fun ApiKeyBottomSheet(
     keyInfo: String,
     onSave: (String) -> Unit,
     onDismiss: () -> Unit,
+    onRemove: (() -> Unit)? = null,
 ) {
     var key by remember { mutableStateOf("") }
     ModalBottomSheet(
@@ -357,16 +398,32 @@ fun ApiKeyBottomSheet(
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                TextButton(onClick = onDismiss) {
-                    Text(stringResource(Res.string.map_providers_cancel))
+                if (onRemove != null) {
+                    TextButton(onClick = onRemove) {
+                        Text(
+                            text = stringResource(Res.string.map_providers_remove_api_key),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                } else {
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(Res.string.map_providers_cancel))
+                    }
                 }
-                Button(
-                    onClick = { onSave(key) },
-                    enabled = key.isNotBlank(),
-                ) {
-                    Text(stringResource(Res.string.map_providers_save))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (onRemove != null) {
+                        TextButton(onClick = onDismiss) {
+                            Text(stringResource(Res.string.map_providers_cancel))
+                        }
+                    }
+                    Button(
+                        onClick = { onSave(key) },
+                        enabled = key.isNotBlank(),
+                    ) {
+                        Text(stringResource(Res.string.map_providers_save))
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/SettingsService.kt
@@ -59,6 +59,8 @@ interface SettingsService {
         key: String,
     )
 
+    suspend fun removeApiKey(keyGroup: String)
+
     suspend fun addCustomProvider(
         id: String,
         displayName: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
@@ -2,6 +2,7 @@ package com.jordankurtz.piawaremobile.settings.usecase.impl
 
 import com.jordankurtz.piawaremobile.di.annotations.IODispatcher
 import com.jordankurtz.piawaremobile.extensions.async
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.model.Async
 import com.jordankurtz.piawaremobile.settings.CustomProviderConfig
 import com.jordankurtz.piawaremobile.settings.Server
@@ -9,7 +10,6 @@ import com.jordankurtz.piawaremobile.settings.ServerType
 import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.TrailDisplayMode
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
-import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.settings.usecase.SettingsService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -129,16 +129,18 @@ class SettingsServiceImpl(
         key: String,
     ) = updateSetting { it.copy(apiKeys = it.apiKeys + (providerId to key.trim())) }
 
-    override suspend fun removeApiKey(keyGroup: String) = updateSetting { settings ->
-        val updatedKeys = settings.apiKeys - keyGroup
-        val activeProviderUsesKey = TileProviders.ALL
-            .filter { it.requiresApiKey && (it.apiKeyGroup ?: it.id) == keyGroup }
-            .any { it.id == settings.mapProviderId }
-        settings.copy(
-            apiKeys = updatedKeys,
-            mapProviderId = if (activeProviderUsesKey) TileProviders.DEFAULT.id else settings.mapProviderId,
-        )
-    }
+    override suspend fun removeApiKey(keyGroup: String) =
+        updateSetting { settings ->
+            val updatedKeys = settings.apiKeys - keyGroup
+            val activeProviderUsesKey =
+                TileProviders.ALL
+                    .filter { it.requiresApiKey && (it.apiKeyGroup ?: it.id) == keyGroup }
+                    .any { it.id == settings.mapProviderId }
+            settings.copy(
+                apiKeys = updatedKeys,
+                mapProviderId = if (activeProviderUsesKey) TileProviders.DEFAULT.id else settings.mapProviderId,
+            )
+        }
 
     override suspend fun addCustomProvider(
         id: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
@@ -9,6 +9,7 @@ import com.jordankurtz.piawaremobile.settings.ServerType
 import com.jordankurtz.piawaremobile.settings.Settings
 import com.jordankurtz.piawaremobile.settings.TrailDisplayMode
 import com.jordankurtz.piawaremobile.settings.repo.SettingsRepository
+import com.jordankurtz.piawaremobile.map.TileProviders
 import com.jordankurtz.piawaremobile.settings.usecase.SettingsService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -127,6 +128,17 @@ class SettingsServiceImpl(
         providerId: String,
         key: String,
     ) = updateSetting { it.copy(apiKeys = it.apiKeys + (providerId to key)) }
+
+    override suspend fun removeApiKey(keyGroup: String) = updateSetting { settings ->
+        val updatedKeys = settings.apiKeys - keyGroup
+        val activeProviderUsesKey = TileProviders.ALL
+            .filter { it.requiresApiKey && (it.apiKeyGroup ?: it.id) == keyGroup }
+            .any { it.id == settings.mapProviderId }
+        settings.copy(
+            apiKeys = updatedKeys,
+            mapProviderId = if (activeProviderUsesKey) TileProviders.DEFAULT.id else settings.mapProviderId,
+        )
+    }
 
     override suspend fun addCustomProvider(
         id: String,

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/usecase/impl/SettingsServiceImpl.kt
@@ -127,7 +127,7 @@ class SettingsServiceImpl(
     override suspend fun setApiKey(
         providerId: String,
         key: String,
-    ) = updateSetting { it.copy(apiKeys = it.apiKeys + (providerId to key)) }
+    ) = updateSetting { it.copy(apiKeys = it.apiKeys + (providerId to key.trim())) }
 
     override suspend fun removeApiKey(keyGroup: String) = updateSetting { settings ->
         val updatedKeys = settings.apiKeys - keyGroup

--- a/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolutionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/jordankurtz/piawaremobile/map/ProviderResolutionTest.kt
@@ -67,10 +67,21 @@ class ProviderResolutionTest {
     }
 
     @Test
-    fun usesBlankKeyWhenNotConfigured() {
+    fun fallsBackToDefaultWhenApiKeyNotConfigured() {
         val settings = Settings(mapProviderId = "stadia-alidade-smooth")
         val result = resolveActiveProviderConfig(settings)
-        assertFalse(result.styleUrl.contains("{api_key}"))
+        assertEquals(TileProviders.DEFAULT.id, result.id)
+    }
+
+    @Test
+    fun fallsBackToDefaultWhenApiKeyIsBlank() {
+        val settings =
+            Settings(
+                mapProviderId = "stadia-alidade-smooth",
+                apiKeys = mapOf("stadia" to ""),
+            )
+        val result = resolveActiveProviderConfig(settings)
+        assertEquals(TileProviders.DEFAULT.id, result.id)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Providers with a configured key now show an edit (pencil) icon next to the "Key configured" badge
- Tapping the icon re-opens the API key sheet pre-populated with Save and a **Remove key** button
- Removing a key clears it from storage and resets the active provider to the default if it depended on that key group
- Removes the `runBlocking` call in `MapModule` that was blocking the main thread on startup; uses `TileProviders.DEFAULT` as the synchronous initial value so the real persisted value flows in asynchronously

## Test plan

- [ ] Configure a Stadia Maps key — "Key configured" badge and edit icon appear
- [ ] Tap the edit icon — sheet opens with empty key field, Save (disabled), Cancel, and Remove key
- [ ] Enter a new key and Save — key is updated, map reloads
- [ ] Open edit sheet and tap Remove key — badge reverts to "API key required", provider resets to default if Stadia was active
- [ ] Cold-start on a fresh install — no ANR (no `runBlocking` on main thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)