### PR TITLE
Rewrite settings screens with grouped card layout

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/Overlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/Overlay.kt
@@ -1,10 +1,10 @@
 package com.jordankurtz.piawaremobile
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -22,6 +22,6 @@ fun Overlay(
         text = stringResource(Res.string.planes_count, numberOfPlanes),
         modifier = modifier.padding(4.dp),
         style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
-        color = Color.Black,
+        color = MaterialTheme.colorScheme.onBackground,
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MainScreen.kt
@@ -4,17 +4,20 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -23,8 +26,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -82,7 +83,6 @@ import piawaremobile.composeapp.generated.resources.zoom_default_title
 import piawaremobile.composeapp.generated.resources.zoom_max_title
 import piawaremobile.composeapp.generated.resources.zoom_min_title
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     onServersClicked: () -> Unit,
@@ -116,26 +116,12 @@ fun MainScreen(
     }
 
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.settings_title)) },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
-            )
-        },
+        topBar = { SettingsTopAppBar(title = stringResource(Res.string.settings_title)) },
     ) { paddingValues ->
         LazyColumn(
             modifier = Modifier.padding(paddingValues),
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
-            // Section: Map
-            item {
-                SettingsSection(title = stringResource(Res.string.map_section_title))
-            }
-
             item {
                 val activeProviderId = settings.getValue()?.mapProviderId ?: TileProviders.DEFAULT.id
                 val builtInMatch = TileProviders.ALL.find { it.id == activeProviderId }
@@ -143,208 +129,186 @@ fun MainScreen(
                     builtInMatch?.displayNameRes?.let { stringResource(it) }
                         ?: settings.getValue()?.customProviders?.find { it.id == activeProviderId }?.displayName
                         ?: activeProviderId
-                SettingsItem(
-                    title = stringResource(Res.string.map_provider_title),
-                    description = providerDisplayName,
-                    onClick = onMapProviderClicked,
-                    trailingIcon = {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_chevron_right),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    },
-                )
+
+                SettingsGroup(title = stringResource(Res.string.map_section_title)) {
+                    SettingsItem(
+                        title = stringResource(Res.string.map_provider_title),
+                        description = providerDisplayName,
+                        onClick = onMapProviderClicked,
+                        trailingIcon = {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_chevron_right),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                    SettingsSwitch(
+                        title = stringResource(Res.string.center_map_on_user_title),
+                        description = stringResource(Res.string.center_map_on_user_description),
+                        checked = settings.getValue()?.centerMapOnUserOnStart ?: false,
+                        onCheckedChange = viewModel::updateCenterMapOnUserOnStart,
+                    )
+                    HorizontalDivider()
+                    SettingsSwitch(
+                        title = stringResource(Res.string.restore_map_position_title),
+                        description = stringResource(Res.string.restore_map_position_description),
+                        checked = settings.getValue()?.restoreMapStateOnStart ?: true,
+                        onCheckedChange = viewModel::updateRestoreMapStateOnStart,
+                    )
+                    HorizontalDivider()
+                    SettingsDropdown(
+                        title = stringResource(Res.string.trail_display_mode_title),
+                        description = stringResource(Res.string.trail_display_mode_description),
+                        selectedValue = settings.getValue()?.trailDisplayMode ?: TrailDisplayMode.ALL,
+                        values = TrailDisplayMode.entries.toTypedArray(),
+                        onValueSelected = viewModel::updateTrailDisplayMode,
+                    )
+                    HorizontalDivider()
+                    SettingsSwitch(
+                        title = stringResource(Res.string.show_minimap_trails_title),
+                        description = stringResource(Res.string.show_minimap_trails_description),
+                        checked = settings.getValue()?.showMinimapTrails ?: true,
+                        onCheckedChange = viewModel::updateShowMinimapTrails,
+                    )
+                    HorizontalDivider()
+                    SettingsSwitch(
+                        title = stringResource(Res.string.show_receiver_locations_title),
+                        description = stringResource(Res.string.show_receiver_locations_description),
+                        checked = settings.getValue()?.showReceiverLocations ?: true,
+                        onCheckedChange = viewModel::updateShowReceiverLocations,
+                    )
+                    HorizontalDivider()
+                    SettingsSwitch(
+                        title = stringResource(Res.string.show_user_location_title),
+                        description = stringResource(Res.string.show_user_location_description),
+                        checked = settings.getValue()?.showUserLocationOnMap ?: true,
+                        onCheckedChange = viewModel::updateShowUserLocationOnMap,
+                    )
+                    HorizontalDivider()
+                    SettingsNumberInput(
+                        title = stringResource(Res.string.zoom_default_title),
+                        value = settings.getValue()?.defaultZoomLevel ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
+                        onValueChange = viewModel::updateDefaultZoomLevel,
+                        range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
+                    )
+                    HorizontalDivider()
+                    SettingsNumberInput(
+                        title = stringResource(Res.string.zoom_min_title),
+                        value = settings.getValue()?.minZoomLevel ?: SettingsRepository.MIN_ZOOM_LEVEL,
+                        onValueChange = viewModel::updateMinZoomLevel,
+                        range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
+                    )
+                    HorizontalDivider()
+                    SettingsNumberInput(
+                        title = stringResource(Res.string.zoom_max_title),
+                        value = settings.getValue()?.maxZoomLevel ?: SettingsRepository.MAX_ZOOM_LEVEL,
+                        onValueChange = viewModel::updateMaxZoomLevel,
+                        range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
+                    )
+                    HorizontalDivider()
+                    SettingsItem(
+                        title = stringResource(Res.string.clear_map_cache_title),
+                        description = stringResource(Res.string.clear_map_cache_description),
+                        onClick = { showClearCacheConfirm = true },
+                    )
+                }
             }
 
             item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.center_map_on_user_title),
-                    description = stringResource(Res.string.center_map_on_user_description),
-                    checked = settings.getValue()?.centerMapOnUserOnStart ?: false,
-                    onCheckedChange = viewModel::updateCenterMapOnUserOnStart,
-                )
+                SettingsGroup(title = stringResource(Res.string.offline_section_title)) {
+                    SettingsItem(
+                        title = stringResource(Res.string.offline_maps_settings_title),
+                        onClick = onOfflineMapsClicked,
+                        trailingIcon = {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_chevron_right),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                }
             }
 
             item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.restore_map_position_title),
-                    description = stringResource(Res.string.restore_map_position_description),
-                    checked = settings.getValue()?.restoreMapStateOnStart ?: true,
-                    onCheckedChange = viewModel::updateRestoreMapStateOnStart,
-                )
+                SettingsGroup(title = stringResource(Res.string.servers_section_title)) {
+                    SettingsItem(
+                        title = stringResource(Res.string.servers_title),
+                        onClick = onServersClicked,
+                        trailingIcon = {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_chevron_right),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                    SettingsNumberInput(
+                        title = stringResource(Res.string.refresh_interval_title),
+                        value =
+                            settings.getValue()?.refreshInterval
+                                ?: SettingsRepository.DEFAULT_REFRESH_INTERVAL,
+                        onValueChange = viewModel::updateRefreshInterval,
+                    )
+                }
             }
 
             item {
-                SettingsDropdown(
-                    title = stringResource(Res.string.trail_display_mode_title),
-                    description = stringResource(Res.string.trail_display_mode_description),
-                    selectedValue = settings.getValue()?.trailDisplayMode ?: TrailDisplayMode.ALL,
-                    values = TrailDisplayMode.entries.toTypedArray(),
-                    onValueSelected = viewModel::updateTrailDisplayMode,
-                )
+                SettingsGroup(title = stringResource(Res.string.flightaware_section_title)) {
+                    SettingsSwitch(
+                        title = stringResource(Res.string.enable_flightaware_api_title),
+                        description = stringResource(Res.string.enable_flightaware_api_description),
+                        checked = settings.getValue()?.enableFlightAwareApi ?: false,
+                        onCheckedChange = viewModel::updateEnableFlightAwareApi,
+                    )
+                    HorizontalDivider()
+                    SettingsTextInput(
+                        title = stringResource(Res.string.flightaware_api_key_title),
+                        value = settings.getValue()?.flightAwareApiKey ?: "",
+                        onValueChange = viewModel::updateFlightAwareApiKey,
+                    )
+                }
             }
 
             item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.show_minimap_trails_title),
-                    description = stringResource(Res.string.show_minimap_trails_description),
-                    checked = settings.getValue()?.showMinimapTrails ?: true,
-                    onCheckedChange = viewModel::updateShowMinimapTrails,
-                )
-            }
-
-            item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.show_receiver_locations_title),
-                    description = stringResource(Res.string.show_receiver_locations_description),
-                    checked = settings.getValue()?.showReceiverLocations ?: true,
-                    onCheckedChange = viewModel::updateShowReceiverLocations,
-                )
-            }
-
-            item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.show_user_location_title),
-                    description = stringResource(Res.string.show_user_location_description),
-                    checked = settings.getValue()?.showUserLocationOnMap ?: true,
-                    onCheckedChange = viewModel::updateShowUserLocationOnMap,
-                )
-            }
-
-            item {
-                SettingsNumberInput(
-                    title = stringResource(Res.string.zoom_default_title),
-                    value = settings.getValue()?.defaultZoomLevel ?: SettingsRepository.DEFAULT_ZOOM_LEVEL,
-                    onValueChange = viewModel::updateDefaultZoomLevel,
-                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
-                )
-            }
-
-            item {
-                SettingsNumberInput(
-                    title = stringResource(Res.string.zoom_min_title),
-                    value = settings.getValue()?.minZoomLevel ?: SettingsRepository.MIN_ZOOM_LEVEL,
-                    onValueChange = viewModel::updateMinZoomLevel,
-                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
-                )
-            }
-
-            item {
-                SettingsNumberInput(
-                    title = stringResource(Res.string.zoom_max_title),
-                    value = settings.getValue()?.maxZoomLevel ?: SettingsRepository.MAX_ZOOM_LEVEL,
-                    onValueChange = viewModel::updateMaxZoomLevel,
-                    range = SettingsRepository.MIN_ZOOM_LEVEL..SettingsRepository.MAX_ZOOM_LEVEL,
-                )
-            }
-
-            item {
-                SettingsItem(
-                    title = stringResource(Res.string.clear_map_cache_title),
-                    description = stringResource(Res.string.clear_map_cache_description),
-                    onClick = { showClearCacheConfirm = true },
-                )
-            }
-
-            // Section: Offline
-            item {
-                SettingsSection(title = stringResource(Res.string.offline_section_title))
-            }
-
-            item {
-                SettingsItem(
-                    title = stringResource(Res.string.offline_maps_settings_title),
-                    onClick = onOfflineMapsClicked,
-                    trailingIcon = {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_chevron_right),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    },
-                )
-            }
-
-            // Section: Servers
-            item {
-                SettingsSection(title = stringResource(Res.string.servers_section_title))
-            }
-
-            item {
-                SettingsItem(
-                    title = stringResource(Res.string.servers_title),
-                    onClick = onServersClicked,
-                    trailingIcon = {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_chevron_right),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    },
-                )
-            }
-
-            item {
-                SettingsNumberInput(
-                    title = stringResource(Res.string.refresh_interval_title),
-                    value =
-                        settings.getValue()?.refreshInterval
-                            ?: SettingsRepository.DEFAULT_REFRESH_INTERVAL,
-                    onValueChange = viewModel::updateRefreshInterval,
-                )
-            }
-
-            // Section: FlightAware
-            item {
-                SettingsSection(title = stringResource(Res.string.flightaware_section_title))
-            }
-
-            item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.enable_flightaware_api_title),
-                    description = stringResource(Res.string.enable_flightaware_api_description),
-                    checked = settings.getValue()?.enableFlightAwareApi ?: false,
-                    onCheckedChange = viewModel::updateEnableFlightAwareApi,
-                )
-            }
-
-            item {
-                SettingsTextInput(
-                    title = stringResource(Res.string.flightaware_api_key_title),
-                    value = settings.getValue()?.flightAwareApiKey ?: "",
-                    onValueChange = viewModel::updateFlightAwareApiKey,
-                )
-            }
-
-            // Section: App
-            item {
-                SettingsSection(title = stringResource(Res.string.app_section_title))
-            }
-
-            item {
-                SettingsSwitch(
-                    title = stringResource(Res.string.open_urls_externally_title),
-                    description = stringResource(Res.string.open_urls_externally_description),
-                    checked = settings.getValue()?.openUrlsExternally ?: false,
-                    onCheckedChange = viewModel::updateOpenUrlsExternally,
-                )
+                SettingsGroup(title = stringResource(Res.string.app_section_title)) {
+                    SettingsSwitch(
+                        title = stringResource(Res.string.open_urls_externally_title),
+                        description = stringResource(Res.string.open_urls_externally_description),
+                        checked = settings.getValue()?.openUrlsExternally ?: false,
+                        onCheckedChange = viewModel::updateOpenUrlsExternally,
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun SettingsSection(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-    )
+fun SettingsGroup(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        )
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        ) {
+            Column(content = content)
+        }
+    }
 }
 
 @Composable
@@ -354,31 +318,28 @@ fun SettingsItem(
     description: String? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
 ) {
-    Column {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = onClick)
-                    .padding(horizontal = 16.dp, vertical = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            if (description != null) {
                 Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                if (description != null) {
-                    Text(
-                        text = description,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
             }
-            trailingIcon?.invoke()
         }
-        HorizontalDivider()
+        trailingIcon?.invoke()
     }
 }
 
@@ -394,47 +355,42 @@ fun <T> SettingsDropdown(
 ) {
     var expanded by remember { mutableStateOf(false) }
 
-    Column {
-        Row(
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = true }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable { expanded = true }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Box {
+            TextButton(onClick = { expanded = true }) {
+                Text(stringFor(selectedValue))
             }
-            Box {
-                TextButton(onClick = { expanded = true }) {
-                    Text(stringFor(selectedValue))
-                }
-                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                    values.forEach { value ->
-                        DropdownMenuItem(
-                            text = { Text(stringFor(value)) },
-                            onClick = {
-                                onValueSelected(value)
-                                expanded = false
-                            },
-                        )
-                    }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                values.forEach { value ->
+                    DropdownMenuItem(
+                        text = { Text(stringFor(value)) },
+                        onClick = {
+                            onValueSelected(value)
+                            expanded = false
+                        },
+                    )
                 }
             }
         }
-        HorizontalDivider()
     }
 }
 
@@ -456,40 +412,37 @@ fun SettingsNumberInput(
         }
     }
 
-    Column(modifier = modifier) {
-        Row(
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+
+        OutlinedTextField(
+            value = textValue,
+            onValueChange = {
+                textValue = it
+                it.toIntOrNull()?.let { v ->
+                    if (range == null || v in range) onValueChange(v)
+                }
+            },
+            singleLine = true,
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.weight(1f),
-            )
-
-            OutlinedTextField(
-                value = textValue,
-                onValueChange = {
-                    textValue = it
-                    it.toIntOrNull()?.let { v ->
-                        if (range == null || v in range) onValueChange(v)
-                    }
-                },
-                singleLine = true,
-                modifier =
-                    Modifier
-                        .width(80.dp)
-                        .padding(start = 16.dp),
-                textStyle = MaterialTheme.typography.bodyLarge,
-                isError = !isValid,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            )
-        }
-        HorizontalDivider()
+                    .width(80.dp)
+                    .padding(start = 16.dp),
+            textStyle = MaterialTheme.typography.bodyLarge,
+            isError = !isValid,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        )
     }
 }
 
@@ -531,35 +484,30 @@ fun SettingsSwitch(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column {
-        Row(
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .clickable { onCheckedChange(!checked) }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Switch(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-                modifier = Modifier.padding(start = 16.dp),
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable { onCheckedChange(!checked) }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        HorizontalDivider()
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.padding(start = 16.dp),
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/MapProvidersScreen.kt
@@ -7,8 +7,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
@@ -22,8 +25,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -44,7 +45,6 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
-import piawaremobile.composeapp.generated.resources.ic_arrow_back
 import piawaremobile.composeapp.generated.resources.ic_edit
 import piawaremobile.composeapp.generated.resources.map_providers_add_custom
 import piawaremobile.composeapp.generated.resources.map_providers_api_key_configured
@@ -63,7 +63,7 @@ import piawaremobile.composeapp.generated.resources.map_providers_title
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@OptIn(ExperimentalUuidApi::class)
 @Composable
 fun MapProvidersScreen(
     onBack: () -> Unit,
@@ -81,22 +81,9 @@ fun MapProvidersScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.map_providers_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+            SettingsTopAppBar(
+                title = stringResource(Res.string.map_providers_title),
+                onBack = onBack,
             )
         },
     ) { paddingValues ->
@@ -233,10 +220,11 @@ fun BuiltInProviderRow(
                 modifier = Modifier.weight(1f),
             )
             if (isSelected) {
-                Text(
-                    text = "✓",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
                 )
             }
         }
@@ -292,10 +280,11 @@ fun ApiKeyProviderRow(
                 }
             }
             if (isSelected) {
-                Text(
-                    text = "✓",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
                 )
             }
         }
@@ -333,10 +322,11 @@ fun CustomProviderRow(
                 )
             }
             if (isSelected) {
-                Text(
-                    text = "✓",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.primary,
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
                 )
             }
             TextButton(onClick = { showDeleteConfirm = true }) {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineMapsScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Map
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,8 +23,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,11 +43,9 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.ic_add
-import piawaremobile.composeapp.generated.resources.ic_arrow_back
 import piawaremobile.composeapp.generated.resources.ic_clear
 import piawaremobile.composeapp.generated.resources.ic_delete
 import piawaremobile.composeapp.generated.resources.ic_refresh
-import piawaremobile.composeapp.generated.resources.navigate_back
 import piawaremobile.composeapp.generated.resources.offline_map_thumbnail
 import piawaremobile.composeapp.generated.resources.offline_map_thumbnail_placeholder
 import piawaremobile.composeapp.generated.resources.offline_maps_add_region
@@ -66,7 +61,6 @@ import piawaremobile.composeapp.generated.resources.offline_maps_region_size
 import piawaremobile.composeapp.generated.resources.offline_maps_region_zoom
 import piawaremobile.composeapp.generated.resources.offline_maps_title
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OfflineMapsScreen(
     onBack: () -> Unit,
@@ -145,27 +139,11 @@ fun OfflineMapsScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.offline_maps_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_arrow_back),
-                            contentDescription = stringResource(Res.string.navigate_back),
-                        )
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+            SettingsTopAppBar(
+                title = stringResource(Res.string.offline_maps_title),
+                onBack = onBack,
                 actions = {
-                    IconButton(
-                        onClick = { showDownloadDialog = true },
-                    ) {
+                    IconButton(onClick = { showDownloadDialog = true }) {
                         Icon(
                             painter = painterResource(Res.drawable.ic_add),
                             contentDescription = stringResource(Res.string.offline_maps_add_region),

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.jordankurtz.piawaremobile.extensions.formattedDate
 import com.jordankurtz.piawaremobile.map.MapLibreMap
@@ -42,7 +41,6 @@ import piawaremobile.composeapp.generated.resources.offline_maps_detail_zoom
 import kotlin.time.Instant
 
 private const val DETAIL_BOUNDS_PATH_ID = "detail_bounds"
-private val BoundsPathColor = Color(0xFF2196F3)
 
 @Composable
 fun OfflineRegionDetailScreen(
@@ -51,6 +49,7 @@ fun OfflineRegionDetailScreen(
     mapViewModel: MapViewModel = koinViewModel(),
 ) {
     val activeProvider by mapViewModel.activeProvider.collectAsState()
+    val boundsPathColor = MaterialTheme.colorScheme.primary
     LaunchedEffect(region.id) {
         val bounds =
             MapBounds(
@@ -62,7 +61,7 @@ fun OfflineRegionDetailScreen(
         mapViewModel.mapStateController.scrollTo(bounds = bounds, padding = Offset(0.15f, 0.15f))
         mapViewModel.mapStateController.addPath(
             id = DETAIL_BOUNDS_PATH_ID,
-            color = BoundsPathColor,
+            color = boundsPathColor,
             width = 2.dp,
             points =
                 listOf(

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/OfflineRegionDetailScreen.kt
@@ -10,15 +10,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -35,12 +30,9 @@ import com.jordankurtz.piawaremobile.map.MapViewModel
 import com.jordankurtz.piawaremobile.map.model.LatLon
 import com.jordankurtz.piawaremobile.map.model.MapBounds
 import com.jordankurtz.piawaremobile.map.offline.OfflineRegion
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
-import piawaremobile.composeapp.generated.resources.ic_arrow_back
-import piawaremobile.composeapp.generated.resources.navigate_back
 import piawaremobile.composeapp.generated.resources.offline_maps_detail_created
 import piawaremobile.composeapp.generated.resources.offline_maps_detail_provider
 import piawaremobile.composeapp.generated.resources.offline_maps_detail_size
@@ -100,7 +92,6 @@ fun OfflineRegionDetailScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun OfflineRegionDetailContent(
     region: OfflineRegion,
@@ -109,22 +100,9 @@ internal fun OfflineRegionDetailContent(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(region.name) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_arrow_back),
-                            contentDescription = stringResource(Res.string.navigate_back),
-                        )
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+            SettingsTopAppBar(
+                title = region.name,
+                onBack = onBack,
             )
         },
     ) { paddingValues ->

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/ServersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/ServersScreen.kt
@@ -5,15 +5,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,8 +27,6 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.ic_add
-import piawaremobile.composeapp.generated.resources.ic_arrow_back
-import piawaremobile.composeapp.generated.resources.navigate_back
 import piawaremobile.composeapp.generated.resources.server_add
 import piawaremobile.composeapp.generated.resources.server_delete_confirm
 import piawaremobile.composeapp.generated.resources.server_delete_confirm_message
@@ -39,7 +34,6 @@ import piawaremobile.composeapp.generated.resources.server_delete_confirm_title
 import piawaremobile.composeapp.generated.resources.server_dialog_cancel
 import piawaremobile.composeapp.generated.resources.servers_title
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ServersScreen(
     onBack: () -> Unit,
@@ -100,27 +94,11 @@ fun ServersScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.servers_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_arrow_back),
-                            contentDescription = stringResource(Res.string.navigate_back),
-                        )
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+            SettingsTopAppBar(
+                title = stringResource(Res.string.servers_title),
+                onBack = onBack,
                 actions = {
-                    IconButton(
-                        onClick = { showAddDialog = true },
-                    ) {
+                    IconButton(onClick = { showAddDialog = true }) {
                         Icon(
                             painter = painterResource(Res.drawable.ic_add),
                             contentDescription = stringResource(Res.string.server_add),

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsScreen.kt
@@ -34,7 +34,13 @@ fun SettingsScreen() {
     Surface(modifier = Modifier.fillMaxSize()) {
         AnimatedContent(
             targetState = currentScreen,
-            transitionSpec = { slideInHorizontally() togetherWith slideOutHorizontally() },
+            transitionSpec = {
+                if (targetState == SettingsScreens.Main) {
+                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                } else {
+                    slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                }
+            },
         ) { screen ->
             when (screen) {
                 SettingsScreens.Main ->
@@ -43,7 +49,7 @@ fun SettingsScreen() {
                         onOfflineMapsClicked = { currentScreen = SettingsScreens.OfflineMaps },
                         onMapProviderClicked = { currentScreen = SettingsScreens.MapProviders },
                     )
-                SettingsScreens.Servers -> ServersScreen(onBack = {})
+                SettingsScreens.Servers -> ServersScreen(onBack = { currentScreen = SettingsScreens.Main })
                 SettingsScreens.MapProviders ->
                     MapProvidersScreen(
                         onBack = { currentScreen = SettingsScreens.Main },

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/settings/ui/SettingsTopAppBar.kt
@@ -1,0 +1,50 @@
+package com.jordankurtz.piawaremobile.settings.ui
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.jordankurtz.piawaremobile.getPlatform
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.ic_arrow_back
+import piawaremobile.composeapp.generated.resources.navigate_back
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsTopAppBar(
+    title: String,
+    onBack: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    val isAndroid = remember { getPlatform().name.startsWith("Android") }
+    val navigationIcon: @Composable () -> Unit = {
+        if (onBack != null) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_arrow_back),
+                    contentDescription = stringResource(Res.string.navigate_back),
+                )
+            }
+        }
+    }
+    if (isAndroid) {
+        TopAppBar(
+            title = { Text(title) },
+            navigationIcon = navigationIcon,
+            actions = actions,
+        )
+    } else {
+        CenterAlignedTopAppBar(
+            title = { Text(title) },
+            navigationIcon = navigationIcon,
+            actions = actions,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Converts the flat settings list into grouped `Card`-wrapped sections matching native iOS/Android settings feel
- Replaces all colored primary-blue `TopAppBar` instances with a new `SettingsTopAppBar` component (centered on iOS/Desktop, left-aligned on Android via `getPlatform()`)
- Fixes direction-aware slide animation — forward pushes right, back slides left
- Fixes `ServersScreen` broken `onBack = {}` no-op
- Replaces `"✓"` emoji checkmarks with `Icons.Filled.Check` vector icons in `MapProvidersScreen`

## Test plan
- [ ] Scroll through all settings sections — each should appear as a rounded card group with dividers between items
- [ ] Navigate forward (Settings → Servers, Map Providers, Offline Maps) — screen slides in from right
- [ ] Navigate back — screen slides in from left
- [ ] Back button on Servers screen now returns to main settings
- [ ] Map Providers: selected provider shows a check icon, not "✓" text
- [ ] On iOS: top bar title is centered; on Android: left-aligned
- [ ] All existing desktop UI tests pass: `./gradlew :composeApp:desktopTest`
- [ ] All unit tests pass: `./gradlew :composeApp:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)