### PR TITLE
Polish flight details bottom sheet UI

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.jordankurtz.piawaremobile.map.cache.TileCache
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.jordankurtz.piawaremobile.map.cache.TileCache

--- a/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/com/jordankurtz/piawaremobile/SettingsScreenAndroidTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import com.jordankurtz.piawaremobile.map.cache.TileCache
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.jordankurtz.piawaremobile.map.cache.TileCache

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/list/AircraftListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/list/AircraftListScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -107,7 +106,6 @@ fun AircraftListScreen(
     val flightDetails by aircraftViewModel.flightDetails.collectAsState()
     var selectedFlightHex by remember { mutableStateOf<String?>(null) }
     var searchQuery by remember { mutableStateOf("") }
-    val expandedHexes = remember { mutableStateSetOf<String>() }
 
     val filteredAircraft =
         remember(aircraft, searchQuery) {
@@ -134,11 +132,6 @@ fun AircraftListScreen(
                     AircraftListItem(
                         aircraftWithServers = aircraftWithServers,
                         userLocation = userLocation,
-                        expanded = aircraftWithServers.aircraft.hex in expandedHexes,
-                        onExpandedChange = { expanded ->
-                            val hex = aircraftWithServers.aircraft.hex
-                            if (expanded) expandedHexes.add(hex) else expandedHexes.remove(hex)
-                        },
                         flightDetails =
                             if (selectedFlightHex == aircraftWithServers.aircraft.hex) {
                                 flightDetails
@@ -257,12 +250,11 @@ private fun EmptyAircraftList() {
 private fun AircraftListItem(
     aircraftWithServers: AircraftWithServers,
     userLocation: Location?,
-    expanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit,
     flightDetails: Async<Flight>,
     onLoadFlightDetails: () -> Unit,
     onOpenFlightPage: () -> Unit,
 ) {
+    var expanded by remember { mutableStateOf(false) }
     val aircraft = aircraftWithServers.aircraft
     val info = aircraftWithServers.info
 
@@ -283,7 +275,7 @@ private fun AircraftListItem(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable { onExpandedChange(!expanded) }
+                .clickable { expanded = !expanded }
                 .background(MaterialTheme.colorScheme.surface)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,10 +26,8 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -224,15 +223,11 @@ fun FlightDetailsSheetContent(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                SecondaryTabRow(selectedTabIndex = tabIndex) {
-                    tabs.forEachIndexed { index, title ->
-                        Tab(
-                            text = { Text(title) },
-                            selected = tabIndex == index,
-                            onClick = { tabIndex = index },
-                        )
-                    }
-                }
+                PillTabRow(
+                    tabs = tabs,
+                    selectedIndex = tabIndex,
+                    onTabSelected = { tabIndex = it },
+                )
 
                 when (tabIndex) {
                     0 -> DetailsTab(aircraft, userLocation)
@@ -603,5 +598,39 @@ private fun formatSecondsToHoursMinutes(seconds: Int): String {
         hours > 0 -> stringResource(Res.string.flight_details_hours_minutes_short, hours, minutes)
         minutes > 0 -> stringResource(Res.string.flight_details_minutes_short, minutes)
         else -> ""
+    }
+}
+
+@Composable
+private fun PillTabRow(
+    tabs: List<String>,
+    selectedIndex: Int,
+    onTabSelected: (Int) -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Row(modifier = Modifier.padding(4.dp)) {
+            tabs.forEachIndexed { index, title ->
+                val selected = index == selectedIndex
+                val tabColor =
+                    if (selected) MaterialTheme.colorScheme.surface else MaterialTheme.colorScheme.surfaceVariant
+                val textColor =
+                    if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = tabColor,
+                    modifier = Modifier.clickable { onTabSelected(index) },
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = textColor,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                    )
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -1,14 +1,25 @@
 package com.jordankurtz.piawaremobile.map
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -16,6 +27,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -45,6 +57,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
+import piawaremobile.composeapp.generated.resources.aircraft_list_loading_flight_details
 import piawaremobile.composeapp.generated.resources.flight_details_actual
 import piawaremobile.composeapp.generated.resources.flight_details_airport_name_code
 import piawaremobile.composeapp.generated.resources.flight_details_departure
@@ -66,6 +79,7 @@ import piawaremobile.composeapp.generated.resources.unfollow_aircraft
 import kotlin.time.Instant
 
 @Suppress("LongParameterList")
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FlightDetailsBottomSheet(
     aircraft: Aircraft?,
@@ -85,6 +99,7 @@ fun FlightDetailsBottomSheet(
         ModalBottomSheet(
             onDismissRequest = onDismissRequest,
             sheetState = sheetState,
+            dragHandle = null,
         ) {
             FlightDetailsSheetContent(
                 aircraft = aircraft,
@@ -99,6 +114,7 @@ fun FlightDetailsBottomSheet(
 }
 
 @Suppress("LongParameterList")
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FlightDetailsSheetContent(
     aircraft: Aircraft?,
@@ -112,54 +128,95 @@ fun FlightDetailsSheetContent(
     val tabs = listOf("Details", "Aircraft", "Route")
 
     Column(
-        modifier =
-            Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        DragHandle()
+
         when (flightDetails) {
             is Async.Error -> {
-                Text(
-                    text = stringResource(Res.string.flight_details_error, flightDetails.message),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                FlightDetailsActionButtons(
-                    aircraft = aircraft,
-                    isFollowing = isFollowing,
-                    onFollowToggle = onFollowToggle,
-                    onOpenFlightPage = onOpenFlightPage,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                DetailsTab(aircraft, userLocation)
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ErrorOutline,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(32.dp),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(Res.string.flight_details_error, flightDetails.message),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    FlightDetailsActionButtons(
+                        aircraft = aircraft,
+                        isFollowing = isFollowing,
+                        onFollowToggle = onFollowToggle,
+                        onOpenFlightPage = onOpenFlightPage,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    DetailsTab(aircraft, userLocation)
+                }
             }
+
             Async.Loading -> {
-                CircularProgressIndicator()
-                Spacer(modifier = Modifier.height(8.dp))
-                FlightDetailsActionButtons(
-                    aircraft = aircraft,
-                    isFollowing = isFollowing,
-                    onFollowToggle = onFollowToggle,
-                    onOpenFlightPage = onOpenFlightPage,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                DetailsTab(aircraft, userLocation)
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(Res.string.aircraft_list_loading_flight_details),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    FlightDetailsActionButtons(
+                        aircraft = aircraft,
+                        isFollowing = isFollowing,
+                        onFollowToggle = onFollowToggle,
+                        onOpenFlightPage = onOpenFlightPage,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    DetailsTab(aircraft, userLocation)
+                }
             }
+
             is Async.Success -> {
                 val flight = flightDetails.data
 
-                Text(
-                    text = stringResource(Res.string.flight_details_flight_number, flight.ident),
-                    style = MaterialTheme.typography.headlineSmall,
-                )
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.flight_details_flight_number, flight.ident),
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    flight.operator?.let { operator ->
+                        Text(
+                            text = operator,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
 
-                Spacer(modifier = Modifier.height(8.dp))
-                FlightDetailsActionButtons(
-                    aircraft = aircraft,
-                    isFollowing = isFollowing,
-                    onFollowToggle = onFollowToggle,
-                    onOpenFlightPage = onOpenFlightPage,
-                )
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    FlightDetailsActionButtons(
+                        aircraft = aircraft,
+                        isFollowing = isFollowing,
+                        onFollowToggle = onFollowToggle,
+                        onOpenFlightPage = onOpenFlightPage,
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -181,17 +238,39 @@ fun FlightDetailsSheetContent(
             }
 
             Async.NotStarted -> {
-                // Aircraft has no flight number — show aircraft details without flight section
-                FlightDetailsActionButtons(
-                    aircraft = aircraft,
-                    isFollowing = isFollowing,
-                    onFollowToggle = onFollowToggle,
-                    onOpenFlightPage = onOpenFlightPage,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    FlightDetailsActionButtons(
+                        aircraft = aircraft,
+                        isFollowing = isFollowing,
+                        onFollowToggle = onFollowToggle,
+                        onOpenFlightPage = onOpenFlightPage,
+                    )
+                }
+                Spacer(modifier = Modifier.height(12.dp))
                 DetailsTab(aircraft, userLocation)
             }
         }
+    }
+}
+
+@Composable
+private fun DragHandle() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            modifier =
+                Modifier
+                    .width(32.dp)
+                    .height(4.dp),
+            shape = RoundedCornerShape(2.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+            content = {},
+        )
     }
 }
 
@@ -202,20 +281,33 @@ fun FlightDetailsActionButtons(
     onFollowToggle: () -> Unit,
     onOpenFlightPage: () -> Unit,
 ) {
+    val compactPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        OutlinedButton(onClick = onFollowToggle) {
-            Text(
-                if (isFollowing) {
-                    stringResource(Res.string.unfollow_aircraft)
-                } else {
-                    stringResource(Res.string.follow_aircraft)
-                },
-            )
+        if (isFollowing) {
+            FilledTonalButton(
+                onClick = onFollowToggle,
+                contentPadding = compactPadding,
+            ) {
+                Text(stringResource(Res.string.unfollow_aircraft))
+            }
+        } else {
+            OutlinedButton(
+                onClick = onFollowToggle,
+                border = ButtonDefaults.outlinedButtonBorder(),
+                contentPadding = compactPadding,
+            ) {
+                Text(stringResource(Res.string.follow_aircraft))
+            }
         }
         if (!aircraft?.flight.isNullOrBlank()) {
-            OutlinedButton(onClick = onOpenFlightPage) {
+            OutlinedButton(
+                onClick = onOpenFlightPage,
+                border = ButtonDefaults.outlinedButtonBorder(),
+                contentPadding = compactPadding,
+            ) {
                 Text(stringResource(Res.string.open_in_flightaware))
             }
         }
@@ -227,19 +319,42 @@ private fun DetailsTab(
     aircraft: Aircraft?,
     userLocation: Location?,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Spacer(modifier = Modifier.height(16.dp))
         MiniMap(
             aircraft = aircraft,
             userLocation = userLocation,
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
         aircraft?.let {
-            AircraftPrimaryDetails(aircraft = it)
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                AircraftPrimaryDetails(
+                    aircraft = it,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
             Spacer(modifier = Modifier.height(8.dp))
-            AircraftLocationDetails(aircraft = it, userLocation = userLocation)
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                AircraftLocationDetails(
+                    aircraft = it,
+                    userLocation = userLocation,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
         }
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
@@ -248,7 +363,10 @@ private fun AircraftTab(
     aircraft: Aircraft?,
     flight: Flight,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Spacer(modifier = Modifier.height(16.dp))
         FlightAircraftDetails(flight = flight)
         Spacer(modifier = Modifier.height(8.dp))
@@ -257,12 +375,16 @@ private fun AircraftTab(
             Spacer(modifier = Modifier.height(8.dp))
             AircraftSignalDetails(aircraft = it)
         }
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
 @Composable
 private fun RouteTab(flight: Flight) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Spacer(modifier = Modifier.height(16.dp))
         flight.origin?.let {
             AirportInfo(
@@ -272,11 +394,13 @@ private fun RouteTab(flight: Flight) {
                 actualTime = flight.actualOut,
                 estimatedTime = flight.estimatedOut,
             )
+            Spacer(modifier = Modifier.height(8.dp))
         }
 
         FlightProgress(flight = flight)
 
         flight.destination?.let {
+            Spacer(modifier = Modifier.height(8.dp))
             AirportInfo(
                 title = stringResource(Res.string.flight_details_destination),
                 airport = it,
@@ -285,6 +409,7 @@ private fun RouteTab(flight: Flight) {
                 estimatedTime = flight.estimatedIn,
             )
         }
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
@@ -298,7 +423,7 @@ fun MiniMap(
         miniMapViewModel.updateMapState(aircraft = aircraft, location = userLocation)
     }
 
-    Card {
+    Card(modifier = Modifier.fillMaxWidth()) {
         OpenStreetMap(
             state = miniMapViewModel.state,
             modifier = Modifier.height(height = 200.dp),
@@ -313,32 +438,41 @@ fun FlightProgress(flight: Flight) {
     if (ete != null && progress != null && progress in 0..100) {
         val remainingSeconds = ete * (1.0 - progress / 100.0)
 
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_downward),
-                contentDescription = stringResource(Res.string.flight_details_flight_progress),
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = "$progress% complete",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp),
             )
-            if (remainingSeconds > 0) {
-                val remainingString = formatSecondsToHoursMinutes(remainingSeconds.toInt())
-                if (remainingString.isNotBlank()) {
-                    Text(
-                        text = stringResource(Res.string.flight_details_remaining_time, remainingString),
-                        modifier = Modifier.padding(horizontal = 8.dp),
-                    )
+
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_arrow_downward),
+                    contentDescription = stringResource(Res.string.flight_details_flight_progress),
+                )
+                if (remainingSeconds > 0) {
+                    val remainingString = formatSecondsToHoursMinutes(remainingSeconds.toInt())
+                    if (remainingString.isNotBlank()) {
+                        Text(
+                            text = stringResource(Res.string.flight_details_remaining_time, remainingString),
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                        )
+                    }
                 }
             }
+
+            LinearProgressIndicator(
+                progress = { (progress / 100.0).toFloat() },
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
-        LinearProgressIndicator(
-            progress = { (progress / 100.0).toFloat() },
-            modifier = Modifier.fillMaxWidth(),
-        )
     }
 }
 
@@ -351,44 +485,88 @@ private fun AirportInfo(
     actualTime: Instant?,
     estimatedTime: Instant?,
 ) {
-    Column(
-        modifier =
-            modifier
-                .padding(horizontal = 8.dp, vertical = 8.dp)
-                .fillMaxWidth(),
-        horizontalAlignment = Alignment.Start,
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
-        Text(text = title, style = MaterialTheme.typography.titleMedium)
-        if (!airport.city.isNullOrBlank()) {
-            Text(text = airport.city)
-        }
-        Text(
-            text =
-                stringResource(
-                    Res.string.flight_details_airport_name_code,
-                    airport.name.orEmpty(),
-                    airport.code.orEmpty(),
-                ),
-        )
-        Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(4.dp))
 
-        scheduledTime?.let { scheduled ->
-            Text(text = stringResource(Res.string.flight_details_scheduled, scheduled.formattedTime))
-        }
+            airport.code?.let { code ->
+                Text(text = code, style = MaterialTheme.typography.headlineMedium)
+            }
+            if (!airport.city.isNullOrBlank()) {
+                Text(
+                    text = airport.city,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            airport.name?.let { name ->
+                if (name.isNotBlank()) {
+                    Text(
+                        text =
+                            stringResource(
+                                Res.string.flight_details_airport_name_code,
+                                name,
+                                airport.code.orEmpty(),
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
 
-        actualTime?.let { actual ->
-            val diff = calculateTimeDifference(scheduledTime, actual)
-            Text(text = stringResource(Res.string.flight_details_actual, actual.formattedTime, diff))
-        }
+            Spacer(modifier = Modifier.height(8.dp))
 
-        // Only show estimated if actual is not present
-        if (actualTime == null) {
-            estimatedTime?.let { estimated ->
-                val diff = calculateTimeDifference(scheduledTime, estimated)
-                Text(text = stringResource(Res.string.flight_details_estimated, estimated.formattedTime, diff))
+            scheduledTime?.let { scheduled ->
+                TimeRow(
+                    formattedLabel = stringResource(Res.string.flight_details_scheduled, scheduled.formattedTime),
+                    highlight = false,
+                )
+            }
+
+            actualTime?.let { actual ->
+                val diff = calculateTimeDifference(scheduledTime, actual)
+                TimeRow(
+                    formattedLabel = stringResource(Res.string.flight_details_actual, actual.formattedTime, diff),
+                    highlight = scheduledTime != null,
+                )
+            }
+
+            if (actualTime == null) {
+                estimatedTime?.let { estimated ->
+                    val diff = calculateTimeDifference(scheduledTime, estimated)
+                    TimeRow(
+                        formattedLabel =
+                            stringResource(
+                                Res.string.flight_details_estimated,
+                                estimated.formattedTime,
+                                diff,
+                            ),
+                        highlight = false,
+                    )
+                }
             }
         }
     }
+}
+
+@Composable
+private fun TimeRow(
+    formattedLabel: String,
+    highlight: Boolean,
+) {
+    Text(
+        text = formattedLabel,
+        style = MaterialTheme.typography.bodyMedium,
+        color = if (highlight) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.padding(vertical = 2.dp),
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -1,5 +1,10 @@
 package com.jordankurtz.piawaremobile.map
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -229,10 +234,16 @@ fun FlightDetailsSheetContent(
                     onTabSelected = { tabIndex = it },
                 )
 
-                when (tabIndex) {
-                    0 -> DetailsTab(aircraft, userLocation)
-                    1 -> AircraftTab(aircraft, flight)
-                    2 -> RouteTab(flight)
+                AnimatedContent(
+                    targetState = tabIndex,
+                    transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+                    label = "tab_content",
+                ) { index ->
+                    when (index) {
+                        0 -> DetailsTab(aircraft, userLocation)
+                        1 -> AircraftTab(aircraft, flight)
+                        else -> RouteTab(flight)
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -40,6 +40,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.jordankurtz.piawaremobile.extensions.formattedTime
 import com.jordankurtz.piawaremobile.location.LocationViewModel
@@ -58,6 +60,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import piawaremobile.composeapp.generated.resources.Res
 import piawaremobile.composeapp.generated.resources.aircraft_list_loading_flight_details
+import piawaremobile.composeapp.generated.resources.aircraft_list_progress_percent
 import piawaremobile.composeapp.generated.resources.flight_details_actual
 import piawaremobile.composeapp.generated.resources.flight_details_airport_name_code
 import piawaremobile.composeapp.generated.resources.flight_details_departure
@@ -259,7 +262,8 @@ private fun DragHandle() {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 12.dp),
+                .padding(top = 8.dp, bottom = 12.dp)
+                .semantics { contentDescription = "" },
         contentAlignment = Alignment.Center,
     ) {
         Surface(
@@ -440,7 +444,7 @@ fun FlightProgress(flight: Flight) {
 
         Column(modifier = Modifier.fillMaxWidth()) {
             Text(
-                text = "$progress% complete",
+                text = stringResource(Res.string.aircraft_list_progress_percent, progress),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 4.dp),

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -54,6 +54,7 @@ import com.jordankurtz.piawaremobile.ui.AircraftLocationDetails
 import com.jordankurtz.piawaremobile.ui.AircraftPrimaryDetails
 import com.jordankurtz.piawaremobile.ui.AircraftSecondaryDetails
 import com.jordankurtz.piawaremobile.ui.AircraftSignalDetails
+import com.jordankurtz.piawaremobile.ui.AppTheme
 import com.jordankurtz.piawaremobile.ui.FlightAircraftDetails
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -367,6 +368,10 @@ private fun AircraftTab(
     aircraft: Aircraft?,
     flight: Flight,
 ) {
+    val emergencySquawkCodes = setOf("7500", "7600", "7700")
+    val emergencyColor = AppTheme.colors.aircraftEmergency
+    val defaultSquawkColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Column(
         modifier = Modifier.padding(horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -375,7 +380,8 @@ private fun AircraftTab(
         FlightAircraftDetails(flight = flight)
         Spacer(modifier = Modifier.height(8.dp))
         aircraft?.let {
-            AircraftSecondaryDetails(aircraft = it)
+            val squawkColor = if (it.squawk in emergencySquawkCodes) emergencyColor else defaultSquawkColor
+            AircraftSecondaryDetails(aircraft = it, squawkValueColor = squawkColor)
             Spacer(modifier = Modifier.height(8.dp))
             AircraftSignalDetails(aircraft = it)
         }

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/map/FlightDetailsBottomSheet.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
@@ -224,7 +224,7 @@ fun FlightDetailsSheetContent(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                PrimaryTabRow(selectedTabIndex = tabIndex) {
+                SecondaryTabRow(selectedTabIndex = tabIndex) {
                     tabs.forEachIndexed { index, title ->
                         Tab(
                             text = { Text(title) },

--- a/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/AircraftComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/jordankurtz/piawaremobile/ui/AircraftComponents.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.jordankurtz.piawaremobile.model.Aircraft
 import com.jordankurtz.piawaremobile.model.AircraftInfo
@@ -51,12 +52,13 @@ fun LabeledValue(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    valueColor: Color = Color.Unspecified,
 ) {
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(value, style = MaterialTheme.typography.bodyLarge)
+        Text(value, style = MaterialTheme.typography.bodyLarge, color = valueColor)
         Text(
             label,
             style = MaterialTheme.typography.labelSmall,
@@ -144,6 +146,7 @@ fun AircraftLocationDetails(
 fun AircraftSecondaryDetails(
     aircraft: Aircraft,
     modifier: Modifier = Modifier,
+    squawkValueColor: Color = Color.Unspecified,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -160,6 +163,7 @@ fun AircraftSecondaryDetails(
             LabeledValue(
                 label = stringResource(Res.string.label_squawk),
                 value = it,
+                valueColor = squawkValueColor,
             )
         }
     }


### PR DESCRIPTION
## Summary
- Custom drag handle pill at top of sheet content
- Follow/Unfollow uses FilledTonalButton (active) vs OutlinedButton (inactive) for clearer state
- DetailsTab: aircraft primary and location details wrapped in Cards with 1dp elevation
- AirportInfo: Card layout with headlineMedium airport code, city hierarchy, and highlighted actual times
- FlightProgress: percent label above the progress bar
- Error state: error icon + styled message text

## Test plan
- [ ] Tap aircraft on map → sheet opens with drag handle
- [ ] Follow button shows filled style when following, outlined when not
- [ ] Details tab: minimap full width, primary/location wrapped in Cards
- [ ] Route tab: airport cards with code at headline size
- [ ] Loading state shows spinner with label
- [ ] Error state shows icon and message
- [ ] All desktop UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)